### PR TITLE
Fix for incorrect luau-lsp config use

### DIFF
--- a/src/pluginsupport.ts
+++ b/src/pluginsupport.ts
@@ -167,7 +167,22 @@ export class LuaLSPPlugin extends BasePlugin {
         // specific to another extension's settings. If desired we could expose a
         // generic configuration proxy later.
         const luaulsp = vscode.workspace.getConfiguration("luau-lsp");
-        await luaulsp.update("types.definitionFiles", [defsFile]);
+
+        // Luau lsp uses a key'd object for this config, but used an array of strings int he past
+        // We will insert our config with prefixed keys to avoid trampling any user defined keys
+        let luaulspDefs = luaulsp.get<{[k:string]:string}|string[]>("types.definitionFiles",{});
+        if(luaulspDefs instanceof Array) {
+            // Discard array config, theres not much else we can do to fix it
+            luaulspDefs = {}
+        }
+        for(const key in luaulspDefs) {
+            if(key.startsWith("sl-")) {
+                delete luaulspDefs[key];
+            }
+        }
+        luaulspDefs["sl-slua"] = defsFile;
+
+        await luaulsp.update("types.definitionFiles", luaulspDefs);
         await luaulsp.update("types.documentationFiles", [docsFile]);
         await luaulsp.update("platform.type", "standard");
         await new Promise((resolve) => setTimeout(resolve, 100));

--- a/src/pluginsupport.ts
+++ b/src/pluginsupport.ts
@@ -175,11 +175,6 @@ export class LuaLSPPlugin extends BasePlugin {
             // Discard array config, theres not much else we can do to fix it
             luaulspDefs = {}
         }
-        for(const key in luaulspDefs) {
-            if(key.startsWith("sl-")) {
-                delete luaulspDefs[key];
-            }
-        }
         luaulspDefs["sl-slua"] = defsFile;
 
         await luaulsp.update("types.definitionFiles", luaulspDefs);


### PR DESCRIPTION
This is a recent change to the luau-lsp extension

<img width="919" height="111" alt="image" src="https://github.com/user-attachments/assets/a372da8a-e803-461b-a103-89ddfbbd2451" />


I ran afoul of it myself with my extension.

This change will remove any existing configs but will allow them to be used better going forward.