### PR TITLE
Switch from class to extern syntax for luau-lsp defs and move DetecteEvent

### DIFF
--- a/data/dev/sl-lua-defs.json
+++ b/data/dev/sl-lua-defs.json
@@ -36,27 +36,6 @@
       }
     },
     {
-      "name": "DetectedEvent",
-      "definition": {
-        "kind": "table",
-        "properties": [
-          {
-            "name": "valid",
-            "type": "boolean"
-          },
-          {
-            "name": "index",
-            "type": "number"
-          },
-          {
-            "name": "can_change_damage",
-            "type": "boolean"
-          }
-        ],
-        "methods": [ ]
-      }
-    },
-    {
       "name": "DetectedEventName",
       "definition": {
         "kind": "literal-union",
@@ -538,6 +517,24 @@
           "comment": "negate a vector"
         }
       ]
+    },
+    {
+      "name": "DetectedEvent",
+      "properties": [
+        {
+          "name": "valid",
+          "type": "boolean"
+        },
+        {
+          "name": "index",
+          "type": "number"
+        },
+        {
+          "name": "can_change_damage",
+          "type": "boolean"
+        }
+      ],
+      "methods": [ ]
     }
   ],
   "globalVariables": [

--- a/data/syntax_def_default.json
+++ b/data/syntax_def_default.json
@@ -15385,6 +15385,24 @@
             "type": "number"
           }
         ]
+      },
+      {
+        "methods": [],
+        "properties": [
+          {
+            "name": "valid",
+            "type": "boolean"
+          },
+          {
+            "name": "index",
+            "type": "number"
+          },
+          {
+            "name": "can_change_damage",
+            "type": "boolean"
+          }
+        ],
+        "name": "DetectedEvent"
       }
     ],
     "globalFunctions": [
@@ -16090,27 +16108,6 @@
           "name": "number"
         },
         "name": "lljson_constant"
-      },
-      {
-        "definition": {
-          "kind": "table",
-          "methods": [],
-          "properties": [
-            {
-              "name": "valid",
-              "type": "boolean"
-            },
-            {
-              "name": "index",
-              "type": "number"
-            },
-            {
-              "name": "can_change_damage",
-              "type": "boolean"
-            }
-          ]
-        },
-        "name": "DetectedEvent"
       },
       {
         "definition": {

--- a/src/shared/languagetransformer.ts
+++ b/src/shared/languagetransformer.ts
@@ -3,7 +3,7 @@
  * Copyright (C) 2025, Linden Research, Inc.
  */
 import { LSLFunction, LSLKeywords } from './lslkeywords';
-import { ConstantDeclaration, FunctionSignature, LiteralUnionType, LuaTypeDefinitions, ModuleDeclaration, Parameter, TableType, TypeAlias } from './luadefsinterface';
+import { ClassDeclaration, ConstantDeclaration, FunctionSignature, LiteralUnionType, LuaTypeDefinitions, ModuleDeclaration, Parameter, TableType, TypeAlias } from './luadefsinterface';
 
 export class LanguageTransformer {
     public static processCombinedDefinitions(lslDefs: LSLKeywords, luaDefs: LuaTypeDefinitions): void {
@@ -22,19 +22,18 @@ export class LanguageTransformer {
     }
 
     private static processFunctions(lslDefs: LSLKeywords, luaDefs: LuaTypeDefinitions): void {
-        const detected_event = LanguageTransformer.findTypeAlias(luaDefs, "DetectedEvent");
+        const detected_event = LanguageTransformer.findClass(luaDefs, "DetectedEvent");
 
         if (!lslDefs.functions) {
             return;
         }
 
         if (detected_event) {
-            let def = detected_event.definition as TableType;
-            if (!def.methods) {
-                def.methods = [];
+            if (!detected_event.methods) {
+                detected_event.methods = [];
             }
         }
-        const detected_methods = detected_event ? (detected_event.definition as TableType).methods : undefined;
+        const detected_methods = detected_event ? detected_event.methods : undefined;
 
         let ll_module: ModuleDeclaration = {
             name: "ll",
@@ -187,6 +186,13 @@ export class LanguageTransformer {
             return undefined;
         }
         return luaDefs.typeAliases.find((alias) => alias.name === name);
+    }
+
+    private static findClass(luaDefs: LuaTypeDefinitions, name:string) : ClassDeclaration | undefined {
+        if(!luaDefs.classes) {
+            return undefined;
+        }
+        return luaDefs.classes.find((cls) => cls.name === name);
     }
 
     private static isDetectedFunction(lslFunc: string): boolean {

--- a/src/shared/luadefsgenerator.ts
+++ b/src/shared/luadefsgenerator.ts
@@ -251,7 +251,7 @@ export class LuauDefsGenerator {
     private generateClasses(classes: ClassDeclaration[]): string {
         return classes.map(cls => {
             const lines: string[] = [];
-            lines.push(`declare class ${cls.name}`);
+            lines.push(`declare extern type ${cls.name} with`);
 
             // Properties
             if (cls.properties && cls.properties.length > 0) {

--- a/src/test/suite/selene-config.test.ts
+++ b/src/test/suite/selene-config.test.ts
@@ -224,8 +224,8 @@ suite('LuauDefsGenerator and DocsJsonGenerator Tests', () => {
         const generator = new LuauDefsGenerator();
         const result = generator.generate(defs);
 
-        assert.ok(result.includes('declare class integer'), 'Should generate integer class');
-        assert.ok(result.includes('declare class vector'), 'Should generate vector class');
+        assert.ok(result.includes('declare extern type integer with'), 'Should generate integer class');
+        assert.ok(result.includes('declare extern type vector with'), 'Should generate vector class');
         assert.ok(result.includes('__add'), 'Should generate operator methods');
         assert.ok(result.includes('x') && result.includes('number'), 'Should generate x property');
         assert.ok(result.includes('y') && result.includes('number'), 'Should generate y property');
@@ -405,7 +405,7 @@ suite('LuauDefsGenerator and DocsJsonGenerator Tests', () => {
         const generator = new LuauDefsGenerator();
         const result = generator.generate(defs);
 
-        assert.ok(result.includes('declare class TestClass'), 'Should generate TestClass');
+        assert.ok(result.includes('declare extern type TestClass with'), 'Should generate TestClass');
         assert.ok(result.includes('overloadedMethod'), 'Should include overloaded method');
     });
 
@@ -476,7 +476,7 @@ suite('LuauDefsGenerator and DocsJsonGenerator Tests', () => {
 
         // Should have all categories
         assert.ok(result.includes('type numeric ='), 'Should have alias');
-        assert.ok(result.includes('declare class Vector'), 'Should have class');
+        assert.ok(result.includes('declare extern type Vector with'), 'Should have class');
         assert.ok(result.includes('declare math:'), 'Should have module');
         assert.ok(result.includes('declare function globalHelper'), 'Should have global function');
         assert.ok(result.includes('declare MAX_VALUE'), 'Should have constant');


### PR DESCRIPTION
This moves the generation of the `DetectedEvent` to use class style output

And also switches the definition file over to using `declare extern type` instead of `declare class`

A further piece of work on the viewer is needed to complete this, as the viewer will still be outputting the `DetectedEvent` in type aliases. see  https://github.com/secondlife/viewer/pull/5015

Resolves #3 