### PR TITLE
Fix default data to have eventname for LLEvents:off

### DIFF
--- a/data/dev/sl-lua-defs.json
+++ b/data/dev/sl-lua-defs.json
@@ -163,6 +163,10 @@
                 "name": "self"
               },
               {
+                "name": "eventName",
+                "type": "EventName"
+              },
+              {
                 "name": "handler",
                 "type": "EventHandler"
               }

--- a/data/syntax_def_default.json
+++ b/data/syntax_def_default.json
@@ -16278,6 +16278,10 @@
                   "name": "self"
                 },
                 {
+                  "name": "eventName",
+                  "type": "EventName"
+                },
+                {
                   "name": "handler",
                   "type": "EventHandler"
                 }


### PR DESCRIPTION
`LLEvents:off`

Takes an `event name` and a `handler`, not just a `handler`