### PR TITLE
Add config to enable/disable the extension, and a command to do it quickly

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "commands": [
       {
         "command": "second-life-scripting.enable",
-        "title": "Enabled Extension in workspace",
+        "title": "Enable Extension in workspace",
         "category": "Second Life"
       },
       {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
   "contributes": {
     "commands": [
       {
+        "command": "second-life-scripting.enable",
+        "title": "Enabled Extension in workspace",
+        "category": "Second Life"
+      },
+      {
         "command": "second-life-scripting.connectWebSocket",
         "title": "Connect WebSocket Client",
         "category": "Second Life"
@@ -47,6 +52,11 @@
       {
         "title": "SL Scripting - UI",
         "properties": {
+          "slVscodeEdit.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Wether the SL VS Code extension is enabled"
+          },
           "slVscodeEdit.ui.statusTimeoutSeconds": {
             "type": "number",
             "default": 3,

--- a/src/configservice.ts
+++ b/src/configservice.ts
@@ -12,6 +12,8 @@ export const STATUS_BAR_TIMEOUT_SECONDS = 3;
 export const SCRIPT_FILE_PATTERN =
   /^sl_script_(.+)_([a-fA-F0-9]{32}|[a-fA-F0-9-]{36})\.(luau|lsl)$/;
 
+
+export const configPrefix = "slVscodeEdit";
 /**
  * Configuration keys
  * Note: Keys marked with '*' are not handled through the configuation UI
@@ -21,6 +23,9 @@ export class ConfigService implements vscode.Disposable, FullConfigInterface {
     private static instance: ConfigService | undefined = undefined;
     private context: vscode.ExtensionContext;
     private SessionConfigs: any = {};
+    private watcher: vscode.Disposable|null = null;
+
+    private configHooks : [string,(configService:FullConfigInterface)=>void][] = []
 
     constructor(context: vscode.ExtensionContext) {
         this.context = context;
@@ -38,7 +43,11 @@ export class ConfigService implements vscode.Disposable, FullConfigInterface {
         //TODO: Cache the configuration values and listen for changes
     }
 
-    dispose(): void {}
+    dispose(): void {
+        if(this.watcher) {
+            this.watcher.dispose();
+        }
+    }
 
     public static getInstance(context?: vscode.ExtensionContext): ConfigService {
         if (!ConfigService.instance) {
@@ -53,7 +62,15 @@ export class ConfigService implements vscode.Disposable, FullConfigInterface {
         return ConfigService.instance;
     }
 
-    public initialize(): void { }
+    public initialize(): void {
+        this.watcher = vscode.workspace.onDidChangeConfiguration((e) => {
+            this.configHooks.filter(hook => e.affectsConfiguration(hook[0])).forEach(hook => hook[1](this));
+        });
+    }
+
+    public on(config:ConfigKey, handler:(configService:FullConfigInterface) => void) : void {
+        this.configHooks.push([`${configPrefix}.${config}`,handler]);
+    }
 
     // ConfigInterface path methods -------------------------------------------------
     public async getExtensionInstallPath(): Promise<NormalizedPath> {
@@ -81,6 +98,10 @@ export class ConfigService implements vscode.Disposable, FullConfigInterface {
         return ConfigService.useLocalConfig();
     }
 
+    public isEnabled() : boolean {
+        return this.getConfig<boolean>(ConfigKey.Enabled) ?? true;
+    }
+
     public getConfig<T>(config: ConfigKey): T | undefined {
         if (config in this.SessionConfigs) {
             return this.SessionConfigs[config] as T;
@@ -97,7 +118,7 @@ export class ConfigService implements vscode.Disposable, FullConfigInterface {
             this.SessionConfigs[config] = value;
             return Promise.resolve();
         }
-        return Promise.resolve(vscode.workspace.getConfiguration("slVscodeEdit").update(config, value, scope?.target === 'global') as unknown as void);
+        return Promise.resolve(vscode.workspace.getConfiguration(configPrefix).update(config, value, scope?.target === 'global') as unknown as void);
     }
 
     public static async getLocalConfigPath(): Promise<vscode.Uri> {

--- a/src/interfaces/configinterface.ts
+++ b/src/interfaces/configinterface.ts
@@ -11,6 +11,7 @@ import { NormalizedPath } from './hostinterface';
 
 /** Keys used by configuration (mirrors LLConfigNames). */
 export enum ConfigKey {
+  Enabled = 'enabled',
   ClientName = 'client.name',
   ClientVersion = 'client.version',
   ClientProtocolVersion = 'client.protocolVersion',
@@ -40,6 +41,10 @@ export interface ConfigScope {
 export interface ConfigInterface {
   /** Read a config value (undefined if not set). */
   getConfig<T>(key: ConfigKey): T | undefined;
+
+  /** Get extensions enabled status */
+  isEnabled() : boolean;
+
   /** Update a config value. Implementations may persist asynchronously. */
   setConfig<T>(key: ConfigKey, value: T, scope?: ConfigScope): Promise<void>;
 

--- a/src/pluginsupport.ts
+++ b/src/pluginsupport.ts
@@ -117,6 +117,10 @@ export class SelenePlugin extends BasePlugin {
             seleneToml.std = "roblox+" + fullConfig;
             saved = await host.writeTOML(tomlPath, seleneToml);
         }
+
+        const selene = vscode.workspace.getConfiguration("selene");
+        await selene.update("warnRoblox", false);
+
         return saved;
     }
 }
@@ -180,7 +184,10 @@ export class LuaLSPPlugin extends BasePlugin {
         await luaulsp.update("types.definitionFiles", luaulspDefs);
         await luaulsp.update("types.documentationFiles", [docsFile]);
         await luaulsp.update("platform.type", "standard");
+        await luaulsp.update("sourcemap.enabled", false);
         await new Promise((resolve) => setTimeout(resolve, 100));
+        // Execute luau-lsp's command to realod the language sever
+        await vscode.commands.executeCommand("luau-lsp.reloadServer")
     }
 
     private async saveLuauLSPDefs(

--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -50,6 +50,8 @@ export class SynchService implements vscode.Disposable {
     public agentId?: string;
     public agentName?: string;
 
+    private disposables : vscode.Disposable[] = [];
+
     private constructor(context: vscode.ExtensionContext) {
         this.context = context;
     }
@@ -62,7 +64,6 @@ export class SynchService implements vscode.Disposable {
                 );
             }
             SynchService.instance = new SynchService(context);
-            SynchService.instance.initialize();
         }
         return SynchService.instance;
     }
@@ -77,6 +78,10 @@ export class SynchService implements vscode.Disposable {
             }
         }
         this.activeSyncs.clear();
+        for(const disposable of this.disposables) {
+            disposable.dispose();
+        }
+        this.disposables = [];
     }
 
     public initialize(): void {
@@ -114,12 +119,12 @@ export class SynchService implements vscode.Disposable {
         // const syntaxInit = this.initializeSyntax();
         // showStatusMessage("Initializing syntax...", syntaxInit);
 
-        this.context.subscriptions.push(onDidOpenListener);
-        this.context.subscriptions.push(onDidCloseListener);
-        this.context.subscriptions.push(onDidDeleteListener);
-        this.context.subscriptions.push(onDidSaveListener);
-        this.context.subscriptions.push(onDidChangeWindowState);
-        this.context.subscriptions.push(onDidChangeActiveTextEditor);
+        this.disposables.push(onDidOpenListener);
+        this.disposables.push(onDidCloseListener);
+        this.disposables.push(onDidDeleteListener);
+        this.disposables.push(onDidSaveListener);
+        this.disposables.push(onDidChangeWindowState);
+        this.disposables.push(onDidChangeActiveTextEditor);
     }
 
     private async initializeSyntax(): Promise<void> {
@@ -651,6 +656,11 @@ export class SynchService implements vscode.Disposable {
     }
     //#endregion
 
+    public activate(): void {
+        this.deactivate();
+        this.initialize();
+    }
+
     //====================================================================
     /**
    * Deactivates the file sync functionality
@@ -658,14 +668,7 @@ export class SynchService implements vscode.Disposable {
     public deactivate(): void {
         try {
             // Dispose of all active syncs synchronously
-            for (const [tempFilePath, scriptSync] of this.activeSyncs) {
-                try {
-                    scriptSync.dispose();
-                } catch (error) {
-                    console.warn(`Error disposing sync for ${tempFilePath}:`, error);
-                }
-            }
-            this.activeSyncs.clear();
+            this.dispose();
         } catch (error) {
             console.warn("Error during SynchService deactivation:", error);
         }

--- a/src/test/suite/diagnostic-integration.test.ts
+++ b/src/test/suite/diagnostic-integration.test.ts
@@ -25,6 +25,10 @@ class MockConfig implements FullConfigInterface {
         }
     }
 
+    isEnabled(): boolean {
+        return true;
+    }
+
     getConfig<T>(key: ConfigKey): T | undefined {
         return this.configValues.get(key) as T | undefined;
     }

--- a/src/test/suite/include-disk-integration.test.ts
+++ b/src/test/suite/include-disk-integration.test.ts
@@ -21,6 +21,10 @@ class TestConfig implements FullConfigInterface {
         this.options = options;
     }
 
+    isEnabled(): boolean {
+        return true;
+    }
+
     getConfig<T>(key: ConfigKey): T | undefined {
         // Return individual config values instead of PreprocessorOptions object
         if (key === ConfigKey.PreprocessorEnable) {

--- a/src/test/suite/lexingpreprocessor.test.ts
+++ b/src/test/suite/lexingpreprocessor.test.ts
@@ -35,6 +35,10 @@ class MockConfig implements FullConfigInterface {
         }
     }
 
+    isEnabled(): boolean {
+        return true;
+    }
+
     getConfig<T>(key: ConfigKey): T | undefined {
         return this.configValues.get(key) as T | undefined;
     }

--- a/src/test/suite/nodehost.test.ts
+++ b/src/test/suite/nodehost.test.ts
@@ -11,6 +11,9 @@ class TestConfig implements FullConfigInterface {
     private data = new Map<ConfigKey, any>();
     private session = new Map<ConfigKey, any>();
     constructor(private root: string) {}
+    isEnabled(): boolean {
+        return true;
+    }
     getConfig<T>(key: ConfigKey): T | undefined { return this.data.get(key); }
     async setConfig<T>(key: ConfigKey, value: T): Promise<void> { this.data.set(key, value); }
     getExtensionInstallPath(): Promise<NormalizedPath> { return Promise.resolve(normalizePath(this.root)); }


### PR DESCRIPTION
Provides a way to turn off the extension if a user desires and then enable it on a per workspace basis.

<img width="912" height="128" alt="image" src="https://github.com/user-attachments/assets/ce35c00a-df0d-4f97-8066-751c05163e79" />
