### PR TITLE
Fix precomp require generating invalid code for files with no trailing line ending

### DIFF
--- a/src/shared/parser.ts
+++ b/src/shared/parser.ts
@@ -1379,8 +1379,8 @@ export class Parser {
         wrapped.push(...moduleTokens);
 
         // Closing: end)()
-        console.log("LAST TOKEN",wrapped[wrapped.length - 1]);
-        if(wrapped[wrapped.length-1].type !== TokenType.NEWLINE) {
+        const last = wrapped[wrapped.length-1];
+        if(last.type !== TokenType.NEWLINE) {
             wrapped.push(new Token(TokenType.NEWLINE, this.lineEnding, lineNumber, lineDirectiveText.length + 1, 1));
         }
         wrapped.push(new Token(TokenType.IDENTIFIER, 'end', lineNumber, 1, 3));
@@ -1606,7 +1606,13 @@ export class Parser {
      * Format: __require_table = nil :: any
      */
     private appendRequireTableCleanup(): void {
-        const line = this.currentOutputLine;
+        let line = this.currentOutputLine;
+
+        const last = this.outputTokens[this.outputTokens.length - 1];
+        if(last && last.type !== TokenType.NEWLINE) {
+            this.outputTokens.push(new Token(TokenType.NEWLINE, this.lineEnding, line, last.column+last.length ,1));
+            line++;
+        }
 
         // __require_table = nil :: any (type cast to allow nil assignment)
         this.outputTokens.push(new Token(TokenType.IDENTIFIER, '__require_table', line, 1, 15));

--- a/src/shared/parser.ts
+++ b/src/shared/parser.ts
@@ -1379,6 +1379,10 @@ export class Parser {
         wrapped.push(...moduleTokens);
 
         // Closing: end)()
+        console.log("LAST TOKEN",wrapped[wrapped.length - 1]);
+        if(wrapped[wrapped.length-1].type !== TokenType.NEWLINE) {
+            wrapped.push(new Token(TokenType.NEWLINE, this.lineEnding, lineNumber, lineDirectiveText.length + 1, 1));
+        }
         wrapped.push(new Token(TokenType.IDENTIFIER, 'end', lineNumber, 1, 3));
         wrapped.push(new Token(TokenType.PAREN_CLOSE, ')', lineNumber, 4, 1));
 


### PR DESCRIPTION
Currently if you save this setup

<img width="948" height="191" alt="image" src="https://github.com/user-attachments/assets/5eaa8057-1401-4bb0-95a9-ec1de2b069f7" />

You end up with

<img width="615" height="450" alt="image" src="https://github.com/user-attachments/assets/04954aef-4f36-4dc7-8bde-7908e8bc1fcc" />


So I've added 2 inserts for new line characters, if the preceding character is not a new line character.

Which results in

<img width="583" height="314" alt="image" src="https://github.com/user-attachments/assets/f32bf9e5-55e6-4897-ba86-0b7dc96d01a6" />
