### PR TITLE
Make saves of included/required files trigger 'saves' on actively sync'd file

### DIFF
--- a/src/scriptsync.ts
+++ b/src/scriptsync.ts
@@ -259,7 +259,6 @@ export class ScriptSync implements vscode.Disposable {
     }
 
     public usesInclude(filePath:string) : boolean {
-        console.log(filePath, this.includedFiles.map(i => i.path));
         return this.includedFiles.some(
             include => include.path === filePath,
         );

--- a/src/scriptsync.ts
+++ b/src/scriptsync.ts
@@ -27,6 +27,7 @@ import { ScriptLanguage } from "./shared/languageservice";
 import { CompilationResult, RuntimeDebug, RuntimeError } from "./viewereditwsclient";
 import { normalizePath } from "./interfaces/hostinterface";
 import { SynchService } from "./synchservice";
+import { IncludeInfo } from "./shared/parser";
 
 //====================================================================
 interface TrackedDocuments {
@@ -47,6 +48,8 @@ export class ScriptSync implements vscode.Disposable {
     private diagnosticSources: Set<string> = new Set();
     private lineMappings?: LineMapping[];
     private config: ConfigService;
+
+    private includedFiles : IncludeInfo[] = [];
 
     //====================================================================
     public constructor(
@@ -255,6 +258,13 @@ export class ScriptSync implements vscode.Disposable {
         this.addDiagnostics(diagnosticList);
     }
 
+    public usesInclude(filePath:string) : boolean {
+        console.log(filePath, this.includedFiles.map(i => i.path));
+        return this.includedFiles.some(
+            include => include.path === filePath,
+        );
+    }
+
     public static preprocessorErrorsToDiagnostics(
         errors: PreprocessorError[],
         sourceName: string = "Second Life Preprocessor"
@@ -384,6 +394,10 @@ export class ScriptSync implements vscode.Disposable {
                             `${preprocessorResult.language} Preprocessor`
                         );
                         this.addDiagnostics(diagnostics);
+                    }
+
+                    if(preprocessorResult.includes && preprocessorResult.includes.length > 0) {
+                        this.includedFiles = preprocessorResult.includes;
                     }
 
                     if (preprocessorResult.success) {

--- a/src/shared/includeprocessor.ts
+++ b/src/shared/includeprocessor.ts
@@ -16,6 +16,7 @@ import { Lexer, Token } from './lexer';
 import { MacroProcessor } from './macroprocessor';
 import { ConditionalProcessor } from './conditionalprocessor';
 import { DiagnosticCollector, DiagnosticSeverity, ErrorCodes } from './diagnostics';
+import { IncludeInfo } from './parser';
 
 /**
  * Result of processing an include directive
@@ -74,16 +75,17 @@ export class IncludeProcessor {
      * @returns Result of the include processing
      */
     public async processInclude(
-        filename: string,
+        include: IncludeInfo,
         sourceFile: NormalizedPath,
-        isRequire: boolean,
         state: IncludeState,
         _macros: MacroProcessor,
         _conditionals: ConditionalProcessor,
         diagnostics?: DiagnosticCollector,
-        line?: number,
         column?: number
     ): Promise<IncludeResult> {
+        const filename = include.file;
+        const line = include.line;
+        const isRequire = include.isRequire;
         // Check max include depth
         if (state.includeDepth >= state.maxIncludeDepth) {
             const error = `Maximum include depth (${state.maxIncludeDepth}) exceeded for file: ${filename}`;
@@ -143,6 +145,8 @@ export class IncludeProcessor {
                 error
             };
         }
+
+        include.path = resolvedPath;
 
         // Check for circular includes
         if (state.includeStack.includes(resolvedPath)) {

--- a/src/shared/lexingpreprocessor.ts
+++ b/src/shared/lexingpreprocessor.ts
@@ -15,7 +15,7 @@ import { ScriptLanguage } from "./languageservice";
 import { NormalizedPath, HostInterface } from "../interfaces/hostinterface";
 import { FullConfigInterface, ConfigKey } from "../interfaces/configinterface";
 import { Lexer } from "./lexer";
-import { Parser } from "./parser";
+import { IncludeInfo, Parser } from "./parser";
 import { MacroProcessor } from "./macroprocessor";
 import { DiagnosticSeverity } from "./diagnostics";
 import { LineMapping } from "./linemapper";
@@ -53,6 +53,7 @@ export interface PreprocessorResult {
     lineMappings?: LineMapping[];
     directiveCount?: number;
     issues: PreprocessorError[];
+    includes?: IncludeInfo[];
 }
 //#endregion
 
@@ -200,6 +201,9 @@ export class LexingPreprocessor {
                     });
                 }
             }
+            for(const include of result.includes) {
+                console.log("INCLUDE: ", include);
+            }
 
             return {
                 content: result.success ? result.source : source,  // Return original source on error, processed source on success
@@ -207,6 +211,7 @@ export class LexingPreprocessor {
                 language,
                 lineMappings: result.mappings,
                 issues,
+                includes: result.includes,
             };
 
         } catch (error) {

--- a/src/shared/lexingpreprocessor.ts
+++ b/src/shared/lexingpreprocessor.ts
@@ -201,9 +201,6 @@ export class LexingPreprocessor {
                     });
                 }
             }
-            for(const include of result.includes) {
-                console.log("INCLUDE: ", include);
-            }
 
             return {
                 content: result.success ? result.source : source,  // Return original source on error, processed source on success

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -450,7 +450,6 @@ export class VSCodeHost implements HostInterface {
 
     uriToFileName(uri: string): NormalizedPath {
         // Handle workspace:// scheme
-        console.log(`uriToFileName: ${uri}`)
         if (uri.startsWith('workspace:///')) {
             const withoutScheme = uri.substring('workspace:///'.length);
             const slashIndex = withoutScheme.indexOf('/');
@@ -474,10 +473,10 @@ export class VSCodeHost implements HostInterface {
             }
 
             const absolutePath = path.join(folder.uri.fsPath, relativePath);
-            console.log(`uriToFileName: becomes ${absolutePath}`);
+            console.log(`uriToFileName: '${uri}' becomes '${absolutePath}'`);
             return normalizePath(absolutePath);
         }
-
+        console.log(`uriToFileName: ${uri}`)
         // Handle standard file:// URLs
         return normalizePath(vscode.Uri.parse(uri).fsPath);
     }


### PR DESCRIPTION
This adds the ability for the preprocessor to return the full paths of files that were included/required, which the sync'd script then stores.

Then on the save of a file in the workspace, if that is not a "master" file, the sync service checks if any of active syncs include the file that was just saved, and if they do, triggers the main save routine.

Currently this requires the main script to have been saved at least once, to build the list of required files. This could be resolved by performing a dry run of the preprocessor, but i have not added that in this pr in case there are other concerns first