### PR TITLE
Implement a check to prevent saving over a file with identicle content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "@types/ws": "^8.18.1",
+        "js-sha256": "^0.11.1",
         "js-yaml": "^4.1.1",
         "vscode-languageclient": "^9.0.1",
         "ws": "^8.18.3"
@@ -2265,6 +2266,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/js-sha256": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,16 @@
         }
       },
       {
+        "title": "SL Scripting - Sync",
+        "properties": {
+          "slVscodeEdit.sync.compareHashBeforeSync": {
+            "type": "boolean",
+            "default": false,
+            "description": "Wether the plugin should fisrt check if there have been any actual changes on save, or to just send it to viewer anyway"
+          }
+        }
+      },
+      {
         "title": "SL Scripting - Preprocessor",
         "properties": {
           "slVscodeEdit.preprocessor.enable": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
           "slVscodeEdit.sync.compareHashBeforeSync": {
             "type": "boolean",
             "default": false,
-            "description": "Wether the plugin should fisrt check if there have been any actual changes on save, or to just send it to viewer anyway"
+            "description": "Whether the plugin should fisrt check if there have been any actual changes on save, or to just send it to viewer anyway"
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
   "dependencies": {
     "@iarna/toml": "^2.2.5",
     "@types/ws": "^8.18.1",
+    "js-sha256": "^0.11.1",
     "js-yaml": "^4.1.1",
     "vscode-languageclient": "^9.0.1",
     "ws": "^8.18.3"

--- a/src/configservice.ts
+++ b/src/configservice.ts
@@ -102,15 +102,13 @@ export class ConfigService implements vscode.Disposable, FullConfigInterface {
         return this.getConfig<boolean>(ConfigKey.Enabled) ?? true;
     }
 
-    public getConfig<T>(config: ConfigKey): T | undefined {
+    public getConfig<T>(config: ConfigKey, defaultValue?:T): T | undefined {
         if (config in this.SessionConfigs) {
             return this.SessionConfigs[config] as T;
         }
-        const configValue = vscode.workspace.getConfiguration("slVscodeEdit").get<T>(config);
-        return (
-            configValue ??
-            undefined
-        );
+        const configuration = vscode.workspace.getConfiguration("slVscodeEdit");
+        if(defaultValue) return configuration.get<T>(config, defaultValue);
+        return configuration.get<T>(config);
     }
 
     public setConfig<T>(config: ConfigKey, value: T, scope?: ConfigScope): Promise<void> {

--- a/src/interfaces/configinterface.ts
+++ b/src/interfaces/configinterface.ts
@@ -28,6 +28,7 @@ export enum ConfigKey {
   PreprocessorIncludePaths = 'preprocessor.includePaths',
   PreprocessorMaxIncludeDepth = 'preprocessor.maxIncludeDepth',
   LastSyntaxID = 'syntax.lastID',
+  CompareHashBeforeSync = 'sync.compareHashBeforeSync',
 }
 
 /** Scope target for configuration updates. */
@@ -41,6 +42,7 @@ export interface ConfigScope {
 export interface ConfigInterface {
   /** Read a config value (undefined if not set). */
   getConfig<T>(key: ConfigKey): T | undefined;
+  getConfig<T>(key: ConfigKey, defaultValue:T): T;
 
   /** Get extensions enabled status */
   isEnabled() : boolean;

--- a/src/scriptsync.ts
+++ b/src/scriptsync.ts
@@ -435,8 +435,7 @@ export class ScriptSync implements vscode.Disposable {
 
             // Walk through all TrackedDocuments and save their finalContents if the hash has changed
             await Promise.all(
-                this.fileMappings
-                    .filter(mapping => mapping.hash !== hash)
+                this.getFileMappingsFilteredByHash(hash)
                     .map((mapping) => {
                         mapping.hash = hash;
                         return fs.promises.writeFile(
@@ -451,6 +450,13 @@ export class ScriptSync implements vscode.Disposable {
         } catch (err: any) {
             vscode.window.showErrorMessage(`Error syncing file: ${err.message}`);
         }
+    }
+
+    private getFileMappingsFilteredByHash(hash:string) : TrackedDocument[] {
+        if(!ConfigService.getInstance().getConfig<boolean>(ConfigKey.CompareHashBeforeSync, false)) {
+            return this.fileMappings;
+        }
+        return this.fileMappings.filter(mapping => mapping.hash !== hash);
     }
 
     private static getCurrentAgentId(): string {

--- a/src/scriptsync.ts
+++ b/src/scriptsync.ts
@@ -28,6 +28,7 @@ import { CompilationResult, RuntimeDebug, RuntimeError } from "./viewereditwscli
 import { normalizePath } from "./interfaces/hostinterface";
 import { SynchService } from "./synchservice";
 import { IncludeInfo } from "./shared/parser";
+import { sha256 } from "js-sha256";
 
 //====================================================================
 interface TrackedDocuments {
@@ -50,6 +51,7 @@ export class ScriptSync implements vscode.Disposable {
     private config: ConfigService;
 
     private includedFiles : IncludeInfo[] = [];
+    private lastHash: string = "";
 
     //====================================================================
     public constructor(
@@ -426,6 +428,13 @@ export class ScriptSync implements vscode.Disposable {
                     `Preprocessing disabled, using original content for: ${baseName}`,
                 );
             }
+
+            const sha = sha256.create();
+            sha.update(finalContent);
+            const hash = sha.hex();
+
+            if(this.lastHash === hash) return;
+            this.lastHash = hash;
 
             // Walk through all TrackedDocuments and save their finalContents
             await Promise.all(

--- a/src/scriptsync.ts
+++ b/src/scriptsync.ts
@@ -436,8 +436,8 @@ export class ScriptSync implements vscode.Disposable {
             // Walk through all TrackedDocuments and save their finalContents if the hash has changed
             await Promise.all(
                 this.fileMappings
-                .filter(mapping => mapping.hash !== hash)
-                .map((mapping) => {
+                    .filter(mapping => mapping.hash !== hash)
+                    .map((mapping) => {
                         mapping.hash = hash;
                         return fs.promises.writeFile(
                             mapping.viewerDocument.fileName,
@@ -445,7 +445,7 @@ export class ScriptSync implements vscode.Disposable {
                             "utf8",
                         );
                     }
-                ),
+                    ),
             );
 
         } catch (err: any) {


### PR DESCRIPTION
This is not really necessary but if you want it.

I have a habit of reflexively hitting `ctrl+s` which causes the plugin to resave the scripts to sl, even if there was no change.

This is a bit wasteful so i added a check, that hashes the finalContent before it is saved to sl, if the hash matches last save, then don't bother.

This adds a new dependency to the project, as standard js cryto is not available in the extension context. However I'm sure a hash algo can be useful for several things, for instance including comments with hashes of files at somepoint might be useful for some users, or exposing hashes of things values for preproc constants.

I chose `js-sha265` as it's widely used and has no further dependencies, or any current know issues.