### PR TITLE
Add __UNIXTIME__ macro for lsl

### DIFF
--- a/doc/preprocessor-guide.md
+++ b/doc/preprocessor-guide.md
@@ -389,6 +389,7 @@ The preprocessor automatically defines the following system macros that are avai
 | `__SHORTFILE__` | Short filename without path | `"main.lsl"` |
 | `__TIME__` | Current time (ISO format) | `"14:30:45"` |
 | `__TIMESTAMP__` | Full ISO timestamp | `"2025-11-18T14:30:45.123Z"` |
+| `__UNIXTIME__` | Unix timestamp timestamp as an integer | `1763751286` |
 
 **Usage Example:**
 

--- a/src/scriptsync.ts
+++ b/src/scriptsync.ts
@@ -478,6 +478,7 @@ export class ScriptSync implements vscode.Disposable {
                 let date = new Date();
                 return `"${date.toISOString()}"`;
             });
+            this.macros.defineSystemMacro("__UNIXTIME__", ()=>  `${Math.floor(Date.now() / 1000)}`);
         }
     }
 


### PR DESCRIPTION
This is an undocumented feature in the fs preprocessor that I contributed a few years back

And is extreemly useful for doing things like auto updating all scripts in sim with remote set pin, by having them compare their compile times.