### PR TITLE
Add LLEvents:once do data for default generation

### DIFF
--- a/data/dev/sl-lua-defs.json
+++ b/data/dev/sl-lua-defs.json
@@ -157,6 +157,42 @@
             ]
           },
           {
+            "name": "once",
+            "parameters": [
+              {
+                "name": "self"
+              },
+              {
+                "name": "eventName",
+                "type": "DetectedEventName"
+              },
+              {
+                "name": "handler",
+                "type": "DetectedEventHandler"
+              }
+            ],
+            "returnType": "EventHandler",
+            "overloads": [
+              {
+                "name": "once",
+                "parameters": [
+                  {
+                    "name": "self"
+                  },
+                  {
+                    "name": "eventName",
+                    "type": "NonDetectedEventName"
+                  },
+                  {
+                    "name": "handler",
+                    "type": "EventHandler"
+                  }
+                ],
+                "returnType": "EventHandler"
+              }
+            ]
+          },
+          {
             "name": "off",
             "parameters": [
               {

--- a/data/syntax_def_default.json
+++ b/data/syntax_def_default.json
@@ -16272,6 +16272,42 @@
               "returnType": "EventHandler"
             },
             {
+              "name": "once",
+              "overloads": [
+                {
+                  "name": "once",
+                  "parameters": [
+                    {
+                      "name": "self"
+                    },
+                    {
+                      "name": "eventName",
+                      "type": "NonDetectedEventName"
+                    },
+                    {
+                      "name": "handler",
+                      "type": "EventHandler"
+                    }
+                  ],
+                  "returnType": "EventHandler"
+                }
+              ],
+              "parameters": [
+                {
+                  "name": "self"
+                },
+                {
+                  "name": "eventName",
+                  "type": "DetectedEventName"
+                },
+                {
+                  "name": "handler",
+                  "type": "DetectedEventHandler"
+                }
+              ],
+              "returnType": "EventHandler"
+            },
+            {
               "name": "off",
               "parameters": [
                 {


### PR DESCRIPTION
Resolves #17

`LLEvents:once` was missing from data files

A matching pr to the viewer has been made here: https://github.com/secondlife/viewer/pull/5036
