### PR TITLE
Selene warnign about list type in ll funcs

### DIFF
--- a/src/shared/seleneyamlgenerator.ts
+++ b/src/shared/seleneyamlgenerator.ts
@@ -518,7 +518,7 @@ class SeleneYamlBuilder {
             "()": "nil",
             "nil": "nil",
             "any": "any",
-            "list": { display: "list" },
+            "list": "table",
             "{}": "table",
             "false": "bool",
             "true": "bool",


### PR DESCRIPTION
Turns out `{display: list}` makes selene upset when using functions that take them and a scripter passes a table...