### PR TITLE
Add support to lexer for luau [[ style strings

### DIFF
--- a/src/shared/lexer.ts
+++ b/src/shared/lexer.ts
@@ -751,7 +751,7 @@ export class Lexer {
 
         const startLine = this.context.lineNumber;
         const startColumn = this.context.columnNumber;
-        
+
         const text = this.readMutliCharBlockStart(delimiter);
 
         this.context.inBlockComment = delimiter;

--- a/src/shared/lexer.ts
+++ b/src/shared/lexer.ts
@@ -15,10 +15,19 @@ import { DiagnosticCollector, ErrorCodes } from "./diagnostics";
 /**
  * Language-specific lexer configuration
  */
+type RegexMultiCharDelimiter = {
+    startingChar: string; // The first character of the starting sequence used to avoid regexing constantly
+    endingChar: string; // The first character of the ending sequence used to avoid regexing constantly
+    startingMatch: RegExp; // Regex to match starting sequence
+    endingMatch: RegExp; // Regex to match ending sequence
+    lengthDifference?: number;
+};
+
+type MultiCharDelimiter = RegexMultiCharDelimiter|[string,string];
+
 export interface LanguageLexerConfig {
     lineCommentPrefix: string; // Line comment prefix (e.g., "//" for LSL, "--" for Luau)
-    blockCommentStart: string; // Block comment start marker (e.g., slash-star)
-    blockCommentEnd: string; // Block comment end marker (e.g., star-slash)
+    blockCommentDelimiters: Array<MultiCharDelimiter>; // block comment delimiters (e.g., "/*" for LSL, "--[[" for Luau)
     logicalOperators: {
         and: string; // Logical AND operator (e.g., "&&" for LSL, "and" for Luau)
         or: string; // Logical OR operator (e.g., "||" for LSL, "or" for Luau)
@@ -31,6 +40,7 @@ export interface LanguageLexerConfig {
     operators?: string[]; // Operators and punctuation
     brackets?: Array<[string, string]>; // Bracket pairs
     stringDelimiters?: string[]; // String delimiters for this language (e.g., ['"', "'"] for LSL, ['"', "'", '`'] for Luau)
+    multiLineStringDelimiters?: MultiCharDelimiter[]; // String delimiters for multi line strings (e.g., luau `[[` or `[==[` etc)
 }
 
 /**
@@ -39,8 +49,9 @@ export interface LanguageLexerConfig {
 export const LANGUAGE_CONFIGS: Record<ScriptLanguage, LanguageLexerConfig> = {
     lsl: {
         lineCommentPrefix: "//",
-        blockCommentStart: "/*",
-        blockCommentEnd: "*/",
+        blockCommentDelimiters: [
+            ["/*","*/"]
+        ],
         logicalOperators: {
             and: "&&",
             or: "||",
@@ -68,8 +79,15 @@ export const LANGUAGE_CONFIGS: Record<ScriptLanguage, LanguageLexerConfig> = {
     },
     luau: {
         lineCommentPrefix: "--",
-        blockCommentStart: "--[[",
-        blockCommentEnd: "]]",
+        blockCommentDelimiters: [
+            {
+                startingChar: "-",
+                endingChar: "]",
+                startingMatch: /^--\[[=]*\[$/, // Regex for `--[=[` with 0-n `=` characters
+                endingMatch: /^\][=]*\]$/, // Regex for `]=]` with 0-n `=` characters
+                lengthDifference: -2, // ending sequence is 2 chars shorter
+            }
+        ],
         logicalOperators: {
             and: "and",
             or: "or",
@@ -94,6 +112,15 @@ export const LANGUAGE_CONFIGS: Record<ScriptLanguage, LanguageLexerConfig> = {
             ["[", "]"],  // Brackets for table indexing
         ],
         stringDelimiters: ['"', "'", '`'],  // Double quotes, single quotes, and backticks
+        multiLineStringDelimiters: [
+            {
+                startingChar: "[",
+                endingChar: "]",
+                startingMatch: /^\[[=]*\[$/, // Regex for `[=[` with 0-n `=` characters
+                endingMatch: /^\][=]*\]$/, // Regex for `]=]` with 0-n `=` characters
+                // allowsNewLines: true,
+            }
+        ],  // Double quotes, single quotes, and backticks
     },
 };
 
@@ -293,8 +320,8 @@ export class Token {
  * Context for lexer state
  */
 interface LexerContext {
-    inBlockComment: boolean;
-    blockCommentLevel: number; // For Lua long bracket syntax: 0 for [[, 1 for [=[, etc.
+    inBlockComment: MultiCharDelimiter|null;
+    blockCommentEndLength: number; // For Lua long bracket syntax: 2 for --[[, 3 for --[=[, etc calculated using RegexMultiCharDelimiter.lengthDifference.
     lineNumber: number;
     columnNumber: number;
 }
@@ -326,8 +353,8 @@ export class Lexer {
         this.source = source;
         this.position = 0;
         this.context = {
-            inBlockComment: false,
-            blockCommentLevel: 0,
+            inBlockComment: null,
+            blockCommentEndLength: 0,
             lineNumber: 1,
             columnNumber: 1,
         };
@@ -398,7 +425,7 @@ export class Lexer {
 
         // Handle block comments (multi-line)
         if (this.context.inBlockComment) {
-            return this.readBlockCommentContent();
+            return this.readBlockCommentContent(this.context.inBlockComment);
         }
 
         const char = this.peek();
@@ -422,6 +449,14 @@ export class Lexer {
         // String literals - check configured delimiters
         if (this.isStringDelimiter(char)) {
             return this.readStringLiteral(char);
+        }
+
+        // Multi line strings -- check configured delimiters
+        if(this.config.multiLineStringDelimiters) {
+            const multiLineStringDelimiter = this.isMultiCharBlockStart(this.config.multiLineStringDelimiters);
+            if (multiLineStringDelimiter) {
+                return this.readMultiLineStringLiteral(multiLineStringDelimiter);
+            }
         }
 
         // Preprocessor directives with prefix (e.g., #include)
@@ -575,26 +610,10 @@ export class Lexer {
         const char = this.peek();
         const nextChar = this.peekAhead(1);
 
-        // For languages with long bracket syntax (Lua), check for block comment FIRST
-        // because block comments start with the line comment prefix
-        const blockStart = this.config.blockCommentStart;
-        if (this.config.useLongBracketSyntax && blockStart) {
-            // Check for start of long bracket comment (e.g., --[)
-            const linePrefix = this.config.lineCommentPrefix;
-            if (linePrefix.length === 2 &&
-                char === linePrefix[0] &&
-                nextChar === linePrefix[1] &&
-                this.peekAhead(2) === '[') {
-                return this.readBlockCommentStart();
-            }
-        } else if (blockStart && blockStart.length >= 2) {
-            // Standard block comment (e.g., /*)
-            const matches = blockStart.length === 2 &&
-                           char === blockStart[0] &&
-                           nextChar === blockStart[1];
-            if (matches) {
-                return this.readBlockCommentStart();
-            }
+        // Check for block comment delimiters
+        const multiLineStart = this.tryReadBlockCommentStart(this.config.blockCommentDelimiters);
+        if(multiLineStart) {
+            return multiLineStart;
         }
 
         // Line comment - check if current position matches line comment prefix
@@ -606,6 +625,97 @@ export class Lexer {
         }
 
         return null;
+    }
+
+    private isMultiCharBlockStart(delimiters: MultiCharDelimiter[]) : MultiCharDelimiter|null {
+        // Loop delimiters and return first match
+        for(const delimiter of delimiters) {
+            if(this.isThisMultiCharBlockStart(delimiter)) {
+                return delimiter;
+            }
+        }
+        return null;
+    }
+
+    private isThisMultiCharBlockStart(delimiter: MultiCharDelimiter) : boolean {
+        let str = this.peek();
+        // Check both delimiter formats, either [stirng, string] or RegexMultiCharDelimiter
+        if(delimiter instanceof Array) {
+            const start = delimiter[0];
+            // Return fast if first char mismatch
+            if(str !== start[0]) return false;
+            let offset = 1;
+            let next = this.peekAhead(offset);
+            // loop peek to build string that matches starting [0] delimiter length
+            while(str.length < start.length && next !== "\0") {
+                str += next;
+                offset++;
+                next = this.peekAhead(offset)
+            }
+            // return if delimiter matches
+            return str === start;
+        } else {
+            // early return if first char doesnt match
+            if (str != delimiter.startingChar) return false;
+            let offset = 1;
+            let next = this.peekAhead(offset);
+            // loop peek to build string checking if it completes the regex
+            while(!delimiter.startingMatch.test(str) && str.length < 11 && next != "\0") {
+                str += next;
+                offset++;
+                next = this.peekAhead(offset);
+            }
+            // return if delimiter matches starting regex
+            return delimiter.startingMatch.test(str);
+        }
+    }
+
+    private isThisMultiCharBlockEnd(delimiter: MultiCharDelimiter, length:number) : boolean {
+        let str = this.peek();
+        // Check both delimiter formats, either [stirng, string] or RegexMultiCharDelimiter
+        if(delimiter instanceof Array) {
+            const end = delimiter[1];
+            // Return fast if first char mismatch
+            if(str !== end[0]) return false;
+            let offset = 1;
+            let next = this.peekAhead(offset);
+            // loop peek to build string that matches given length
+            while(str.length < length && next !== "\0") {
+                str += next;
+                offset++;
+                next = this.peekAhead(offset)
+            }
+            // Return if built string matches end sequence
+            return str === end;
+        } else {
+            // Return fast if first char mismatch
+            if (str != delimiter.endingChar) return false;
+            let offset = 1;
+            let next = this.peekAhead(offset);
+            // loop peek to build string that matches given length
+            while(str.length < length && next != "\0") {
+                str += next;
+                offset++;
+                next = this.peekAhead(offset);
+            }
+            // Return if built string matches regex
+            return delimiter.endingMatch.test(str);
+        }
+    }
+
+    private readMutliCharBlockStart(delimiter: MultiCharDelimiter) : string {
+        let str = "";
+        // read starting sequence of delimiter after we have tested for it.
+        if(delimiter instanceof Array) {
+            while(str.length < delimiter[0].length) {
+                str += this.advance();
+            }
+        } else {
+            while(str.length < 11 && !delimiter.startingMatch.test(str)) {
+                str += this.advance();
+            }
+        }
+        return str;
     }
 
     private readLineComment(): Token {
@@ -633,109 +743,41 @@ export class Lexer {
         );
     }
 
-    private readBlockCommentStart(): Token {
-        const startLine = this.context.lineNumber;
-        const startColumn = this.context.columnNumber;
-
-        // Consume the block comment start (configured)
-        const start = this.config.blockCommentStart;
-        let value = "";
-
-        // For Lua-style long brackets: --[=*[
-        // Detect the level of equals signs
-        let equalsLevel = 0;
-
-        if (this.config.useLongBracketSyntax) {
-            // Read line comment prefix (e.g., "--")
-            const linePrefix = this.config.lineCommentPrefix;
-            for (let i = 0; i < linePrefix.length; i++) {
-                value += this.advance();
-            }
-
-            // Read opening bracket
-            const openBracket = this.config.blockCommentStart.charAt(linePrefix.length);
-            if (this.peek() === openBracket) {
-                value += this.advance();
-            }
-
-            // Count equals signs
-            while (this.peek() === '=') {
-                value += this.advance();
-                equalsLevel++;
-            }
-
-            // Read the final bracket (same as opening bracket)
-            if (this.peek() === openBracket) {
-                value += this.advance();
-            }
-        } else {
-            // Standard block comment (e.g., /* */)
-            for (let i = 0; i < start.length; i++) {
-                value += this.advance();
-            }
+    private tryReadBlockCommentStart(delimiters: MultiCharDelimiter[]) : Token|null {
+        const delimiter = this.isMultiCharBlockStart(delimiters);
+        if(!delimiter) {
+            return null;
         }
 
-        this.context.inBlockComment = true;
-        this.context.blockCommentLevel = equalsLevel;
+        const startLine = this.context.lineNumber;
+        const startColumn = this.context.columnNumber;
+        
+        const text = this.readMutliCharBlockStart(delimiter);
+
+        this.context.inBlockComment = delimiter;
+        if(delimiter instanceof Array) {
+            this.context.blockCommentEndLength = delimiter[1].length;
+        } else {
+            this.context.blockCommentEndLength = text.length + (delimiter.lengthDifference ?? 0)
+        }
 
         return new Token(
             TokenType.BLOCK_COMMENT_START,
-            value,
+            text,
             startLine,
             startColumn,
-            value.length
+            text.length
         );
     }
 
-    private readBlockCommentContent(): Token {
+    private readBlockCommentContent(delimiter: MultiCharDelimiter): Token {
         const startLine = this.context.lineNumber;
         const startColumn = this.context.columnNumber;
+        const endLength = this.context.blockCommentEndLength;
         let value = "";
-        const endMarker = this.config.blockCommentEnd;
+        while(!this.isAtEnd()) {
+            if(this.isThisMultiCharBlockEnd(delimiter, endLength)) {
 
-        while (!this.isAtEnd()) {
-            const char = this.peek();
-
-            // Check for block comment end
-            let matchesEnd = false;
-            let endLength = 0;
-
-            if (this.config.useLongBracketSyntax) {
-                // Lua-style long brackets: ]=*]
-                // Must match the same number of equals signs as the start
-                if (char === ']') {
-                    let tempPos = this.position;
-                    let equalsCount = 0;
-
-                    // Skip ']'
-                    tempPos++;
-
-                    // Count equals signs
-                    while (tempPos < this.source.length && this.source[tempPos] === '=') {
-                        equalsCount++;
-                        tempPos++;
-                    }
-
-                    // Check for final ']'
-                    if (tempPos < this.source.length &&
-                        this.source[tempPos] === ']' &&
-                        equalsCount === this.context.blockCommentLevel) {
-                        matchesEnd = true;
-                        endLength = 2 + equalsCount; // ']' + equals + ']'
-                    }
-                }
-            } else {
-                // Standard block comment (e.g., */)
-                const nextChar = this.peekAhead(1);
-                matchesEnd = endMarker.length === 2 &&
-                           char === endMarker[0] &&
-                           nextChar === endMarker[1];
-                endLength = endMarker.length;
-            }
-
-            if (matchesEnd) {
-                // If we have accumulated content, return it first
-                // The end marker will be returned on the next call
                 if (value.length > 0) {
                     return new Token(
                         TokenType.BLOCK_COMMENT_CONTENT,
@@ -746,23 +788,20 @@ export class Lexer {
                     );
                 }
 
-                // Return the end token
-                let endValue = "";
-                for (let i = 0; i < endLength; i++) {
-                    endValue += this.advance();
+                while(value.length < endLength && !this.isAtEnd()) {
+                    value += this.advance();
                 }
-                this.context.inBlockComment = false;
-                this.context.blockCommentLevel = 0;
-
+                this.context.inBlockComment = null;
+                this.context.blockCommentEndLength = 0;
                 return new Token(
                     TokenType.BLOCK_COMMENT_END,
-                    endValue,
+                    value,
                     startLine,
                     startColumn,
-                    endLength
+                    value.length
                 );
             }
-
+            const char = this.peek();
             if (char === '\n' || char === '\r') {
                 // Include newline in comment content
                 if (char === '\r' && this.peekAhead(1) === '\n') {
@@ -825,6 +864,59 @@ export class Lexer {
 
         // Check if we reached end of file without closing quote
         if (this.isAtEnd() && !value.endsWith(quoteChar)) {
+            this.diagnostics.addError(
+                `Unterminated string literal`,
+                {
+                    line: startLine,
+                    column: startColumn,
+                    length: value.length,
+                    sourceFile: this.sourceFile,
+                },
+                ErrorCodes.UNTERMINATED_STRING
+            );
+        }
+
+        return new Token(
+            TokenType.STRING_LITERAL,
+            value,
+            startLine,
+            startColumn,
+            value.length
+        );
+    }
+
+    private readMultiLineStringLiteral(delimiter: MultiCharDelimiter): Token {
+        const startLine = this.context.lineNumber;
+        const startColumn = this.context.columnNumber;
+
+        let value = this.readMutliCharBlockStart(delimiter);
+        const endLength = value.length + (delimiter instanceof Array ? 0 : (delimiter.lengthDifference ?? 0));
+        let ended = false;
+        while (!this.isAtEnd()) {
+            if (this.isThisMultiCharBlockEnd(delimiter, endLength)) {
+                let end = "";
+                while (end.length < endLength && !this.isAtEnd()) {
+                    end += this.advance();
+                }
+                value += end;
+                ended = end.length == endLength;
+                break;
+            }
+            const char = this.peek();
+            if (char === '\n' || char === '\r') {
+                // Include newline in multi line string content
+                if (char === '\r' && this.peekAhead(1) === '\n') {
+                    value += this.advance();
+                }
+                value += this.advance();
+                this.context.lineNumber++;
+                this.context.columnNumber = 1;
+            } else {
+                value += this.advance();
+            }
+        }
+
+        if(!ended) {
             this.diagnostics.addError(
                 `Unterminated string literal`,
                 {
@@ -1251,10 +1343,7 @@ export class Lexer {
     //#region Helper methods
 
     private peek(): string {
-        if (this.isAtEnd()) {
-            return '\0';
-        }
-        return this.source[this.position];
+        return this.peekAhead(0);
     }
 
     private peekAhead(offset: number): string {
@@ -1283,9 +1372,8 @@ export class Lexer {
     }
 
     private advance(): string {
-        const char = this.source[this.position++];
         this.context.columnNumber++;
-        return char;
+        return this.source[this.position++];
     }
 
     private isAtEnd(): boolean {

--- a/src/test/suite/lexingpreprocessor.test.ts
+++ b/src/test/suite/lexingpreprocessor.test.ts
@@ -15,6 +15,7 @@ import {
 import { LexingPreprocessor, PreprocessorOptions } from "../../shared/lexingpreprocessor";
 import { normalizePath, HostInterface, NormalizedPath } from "../../interfaces/hostinterface";
 import { FullConfigInterface, ConfigKey } from "../../interfaces/configinterface";
+import { ScriptLanguage } from "../../shared/languageservice";
 
 /**
  * Mock configuration class for testing
@@ -291,12 +292,14 @@ suite("Lexing Preprocessor Test Suite", () => {
             const lexer1 = new Lexer(source1, "luau");
             const tokens1 = lexer1.tokenize();
 
-            assert.strictEqual(tokens1[0].type, TokenType.BLOCK_COMMENT_START);
-            assert.strictEqual(tokens1[0].value, "--[=[");
-            assert.strictEqual(tokens1[1].type, TokenType.BLOCK_COMMENT_CONTENT);
-            assert.ok(tokens1[1].value.includes("]] inside"));
-            assert.strictEqual(tokens1[2].type, TokenType.BLOCK_COMMENT_END);
-            assert.strictEqual(tokens1[2].value, "]=]");
+            console.log(tokens1);
+
+            assert.strictEqual(tokens1[0].type, TokenType.BLOCK_COMMENT_START, "Expected Block comment start");
+            assert.strictEqual(tokens1[0].value, "--[=[", `Expected --[=[ got ${tokens1[0].value}`);
+            assert.strictEqual(tokens1[1].type, TokenType.BLOCK_COMMENT_CONTENT, "Expected block comment content");
+            assert.ok(tokens1[1].value.includes("]] inside"), "Comment content did not include expected");
+            assert.strictEqual(tokens1[2].type, TokenType.BLOCK_COMMENT_END, "Expected block comment end");
+            assert.strictEqual(tokens1[2].value, "]=]", `Expected ]=] got ${tokens1[2].value}`);
 
             // Test --[==[ ... ]==]
             const source2 = `--[==[\nDouble equals level\n]==]`;
@@ -340,54 +343,116 @@ suite("Lexing Preprocessor Test Suite", () => {
             assert.strictEqual(lslStrings[1].value, `'single'`);
 
             // Test Luau with double, single, and backticks
-            const luauSource = `"double" 'single' \`backtick\``;
+            const luauSourceStrings = [
+                `"double"`,
+                `'single'`,
+                '`backtick`',
+                "[[square]]",
+                "[=[square equals]=]",
+            ]
+            const luauSource = luauSourceStrings.join(" ");
             const luauLexer = new Lexer(luauSource, "luau");
             const luauTokens = luauLexer.tokenize();
 
+            assert.ok(!luauLexer.getDiagnostics().hasErrors(),"Luau Lexer has errors: " + JSON.stringify(luauLexer.getDiagnostics().getErrors(),null,2));
+
             const luauStrings = luauTokens.filter(t => t.type === TokenType.STRING_LITERAL);
-            assert.strictEqual(luauStrings.length, 3);
-            assert.strictEqual(luauStrings[0].value, `"double"`);
-            assert.strictEqual(luauStrings[1].value, `'single'`);
-            assert.strictEqual(luauStrings[2].value, `\`backtick\``);
+            for(const i in luauSourceStrings) {
+                assert.strictEqual(luauStrings[i]?.value, luauSourceStrings[i]);
+            }
+            assert.strictEqual(luauStrings.length, luauSourceStrings.length);
         });
+
+        const tokenizeAndGetStrings = (strings:string[],lang:ScriptLanguage) : string[] => {
+            const lexer = new Lexer(strings.join(" "),lang);
+            const tokens = lexer.tokenize().filter(t => t.type == TokenType.STRING_LITERAL);
+            return tokens.map(t => t.value);
+        };
 
         test("should handle embedded quotes in strings", () => {
             // Test single quotes inside double-quoted strings
-            const source1 = `"This is a 'string'"`;
-            const lexer1 = new Lexer(source1, "lsl");
-            const tokens1 = lexer1.tokenize();
-
-            const strings1 = tokens1.filter(t => t.type === TokenType.STRING_LITERAL);
-            assert.strictEqual(strings1.length, 1);
-            assert.strictEqual(strings1[0].value, `"This is a 'string'"`);
+            const source1 = [`"This is a 'string'"`];
+            const strings1 = tokenizeAndGetStrings(source1, "lsl");
+            for(const i in source1) {
+                assert.strictEqual(strings1[i], source1[i]);
+            }
+            assert.strictEqual(strings1.length, source1.length);
 
             // Test double quotes inside single-quoted strings
-            const source2 = `'embedded "double" quote'`;
-            const lexer2 = new Lexer(source2, "lsl");
-            const tokens2 = lexer2.tokenize();
-
-            const strings2 = tokens2.filter(t => t.type === TokenType.STRING_LITERAL);
-            assert.strictEqual(strings2.length, 1);
-            assert.strictEqual(strings2[0].value, `'embedded "double" quote'`);
+            const source2 = [`'embedded "double" quote'`];
+            const strings2 = tokenizeAndGetStrings(source2, "lsl");
+            for(const i in source2) {
+                assert.strictEqual(strings2[i], source2[i]);
+            }
+            assert.strictEqual(strings2.length, source2.length);
 
             // Test mixed quotes in Luau with backticks
-            const source3 = `\`can contain "double" and 'single' quotes\``;
-            const lexer3 = new Lexer(source3, "luau");
-            const tokens3 = lexer3.tokenize();
-
-            const strings3 = tokens3.filter(t => t.type === TokenType.STRING_LITERAL);
-            assert.strictEqual(strings3.length, 1);
-            assert.strictEqual(strings3[0].value, `\`can contain "double" and 'single' quotes\``);
+            const source3 = [`\`can contain "double" and 'single' quotes\``];
+            const strings3 = tokenizeAndGetStrings(source3, "luau");
+            for(const i in source3) {
+                assert.strictEqual(strings3[i], source3[i]);
+            }
+            assert.strictEqual(strings3.length, source3.length);
 
             // Test multiple strings with different delimiters
-            const source4 = `"first 'has' single" 'second "has" double'`;
-            const lexer4 = new Lexer(source4, "lsl");
-            const tokens4 = lexer4.tokenize();
+            const source4 = [`"first 'has' single"`,`'second "has" double'`];
+            const strings4 = tokenizeAndGetStrings(source4,"lsl");
+            for(const i in source4) {
+                assert.strictEqual(strings4[i], source4[i]);
+            }
+            assert.strictEqual(strings4.length, source4.length);
 
-            const strings4 = tokens4.filter(t => t.type === TokenType.STRING_LITERAL);
-            assert.strictEqual(strings4.length, 2);
-            assert.strictEqual(strings4[0].value, `"first 'has' single"`);
-            assert.strictEqual(strings4[1].value, `'second "has" double'`);
+            const source5 = [
+                `"first 'has' single"`,
+                `'second "has" double'`,
+                `\`third "has" 'both'\``,
+                `[["fourth" 'has' \`three\`]]`,
+                `[=["fourth" 'has' \`three\` [[and one more]]]=]`,
+            ];
+            const strings5 = tokenizeAndGetStrings(source5,"luau");
+            for(const i in source5) {
+                assert.strictEqual(strings5[i], source5[i]);
+            }
+            assert.strictEqual(strings5.length, source5.length);
+
+            const source6 = [
+                `[===[now we[[[[[]]]]] are [==[]][[[===[]]]] just really messing [][][[][][[[]]]] around]]] ]====] ]===]`,
+                `[===[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[===]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]===]`,
+            ];
+            const strings6 = tokenizeAndGetStrings(source6,"luau");
+            for(const i in source6) {
+                assert.strictEqual(strings6[i], source6[i]);
+            }
+            assert.strictEqual(strings6.length, source6.length);
+
+        });
+
+        test("should handle newlines in strings", () => {
+            // Test that luau can handle newlines in strings delimited by [[ ]]
+            const source1 = [
+                `[===[strings with 'qoutes' \`backticks\` and \n new\nlines\n\n\n\nin\n them \n]===]`,
+                `[===[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[=\n=]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]===]`,
+                `[[hello\nbye]]`,
+                `[[\n]]`,
+                `[[hello\n]]`,
+                `[[\nbye]]`,
+                `[[\nbye]]`,
+                `[[\n\t\t]]`,
+                `[[\t\t\n\t\t]]`,
+            ];
+            const strings1 = tokenizeAndGetStrings(source1,"luau");
+            for(const i in source1) {
+                assert.strictEqual(strings1[i], source1[i]);
+            }
+            assert.strictEqual(strings1.length, source1.length);
+
+            // And windows style
+            const source2 = source1.map(s => s.replaceAll("\n","\r\n"));
+            const strings2 = tokenizeAndGetStrings(source2,"luau");
+            for(const i in source2) {
+                assert.strictEqual(strings2[i], source2[i]);
+            }
+            assert.strictEqual(strings2.length, source2.length);
         });
 
         test("should recognize LSL preprocessor directives", () => {
@@ -623,8 +688,9 @@ suite("Lexing Preprocessor Test Suite", () => {
             // Create a custom language config with Python-style comments
             const customConfig: LanguageLexerConfig = {
                 lineCommentPrefix: "#",
-                blockCommentStart: "'''",
-                blockCommentEnd: "'''",
+                // blockCommentStart: "'''",
+                // blockCommentEnd: "'''",
+                blockCommentDelimiters:[["'''","'''"]],
                 logicalOperators: {
                     and: "&&",
                     or: "||",
@@ -652,8 +718,9 @@ suite("Lexing Preprocessor Test Suite", () => {
             // Create a custom language config with unique operators
             const customConfig: LanguageLexerConfig = {
                 lineCommentPrefix: "//",
-                blockCommentStart: "/*",
-                blockCommentEnd: "*/",
+                // blockCommentStart: "/*",
+                // blockCommentEnd: "*/",
+                blockCommentDelimiters: [["/*","*/"]],
                 logicalOperators: {
                     and: "&&",
                     or: "||",
@@ -681,8 +748,9 @@ suite("Lexing Preprocessor Test Suite", () => {
             // Create a custom language config with standard brackets
             const customConfig: LanguageLexerConfig = {
                 lineCommentPrefix: "//",
-                blockCommentStart: "/*",
-                blockCommentEnd: "*/",
+                // blockCommentStart: "/*",
+                // blockCommentEnd: "*/",
+                blockCommentDelimiters: [["/*","*/"]],
                 logicalOperators: {
                     and: "&&",
                     or: "||",


### PR DESCRIPTION
Resolves #23

 - Added support for Luau `[[` strings
 - Reworked the `--[=[` comment detection to use the same generic mechanism
 - Refactored some string tests to simplify writing them
 - Added tests for `[[` and `[=[` string detection in luau
 - Added tests for `[[` strings with both unix and windows line endings