### PR TITLE
Alter path in selene.toml to be relative

### DIFF
--- a/src/pluginsupport.ts
+++ b/src/pluginsupport.ts
@@ -114,7 +114,8 @@ export class SelenePlugin extends BasePlugin {
             let seleneToml: any = {};
             seleneToml = (await host?.readTOML(tomlPath)) || {};
             const fullConfig = normalizeJoinPath(configPath, `${basename}`);
-            seleneToml.std = "roblox+" + fullConfig;
+            const relativeConfig = vscode.workspace.asRelativePath(fullConfig);
+            seleneToml.std = "luau+" + relativeConfig;
             saved = await host.writeTOML(tomlPath, seleneToml);
         }
 


### PR DESCRIPTION
Resolves #19 

makes the `std` config in `selene.toml` relative rather than absoloute
