### PR TITLE
Add support to slua require for aliases and default init files

### DIFF
--- a/doc/preprocessor-guide.md
+++ b/doc/preprocessor-guide.md
@@ -7,7 +7,7 @@ The Second Life Script Preprocessor is a comprehensive tool that supports advanc
 1. [Overview](#overview)
 2. [Directive Syntax](#directive-syntax)
 3. [Include Directives](#include-directives)
-4. [Require Syntax (SLua/Luau)](#require-syntax-sluaaluau)
+4. [Require Syntax (SLua/Luau)](#require-syntax-slualuau)
 5. [Include vs Require Behavior](#include-vs-require-behavior)
 6. [Macro Definitions (Defines)](#macro-definitions-defines)
 7. [Conditional Processing](#conditional-processing)
@@ -150,6 +150,38 @@ local helper = require("include/helper.luau")  -- If include/ exists relative to
 ```
 
 > **Note**: If you have a file structure like `/project/src/main.luau` and `/project/include/utils.luau`, you would use `require("../include/utils.luau")` from main.luau, NOT `require("utils.luau")`.
+
+### Aliased require syntax
+Require can make use of `.luaurc` files to find modules to pull in by a named prefix instead of a full path.
+
+Example:
+
+#### Directoey Structure
+```
+ ├ .luaurc
+ ├ main.luau
+ ├┬ dir/
+ │├ .luaurc
+ │└ script.luau
+```
+`main.luau` would only use aliases from the top level `.luaurc` file
+
+`script.luau` would use aliases from both
+
+#### Example `.luaurc` content
+```json
+{
+    "aliases": {
+        "library": "C:\\Users\\User\\Scripts\\Library"
+    }
+}
+```
+A script that checks a `.luaurc` with the above content could require files like this
+
+```lua
+local lib = require("@library/lib") -- would look for `C:\Users\User\Scripts\Library\lib`
+```
+
 
 ### How Require Works
 
@@ -1063,6 +1095,7 @@ default {
 - Be mindful that the same module can be required multiple times
 - Keep module dependencies shallow to avoid hitting depth limits
 - Use clear module naming to make dependencies obvious
+- Make use of the [`.luaurc` file format](https://rfcs.luau.org/require-by-string-aliases.html) to alias requires or to add modules external to your workspace.
 
 **Example:**
 ```luau

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "engines": {
     "vscode": "^1.85.0"
   },
+  "license": "MIT",
   "categories": [
     "Programming Languages",
     "Other"

--- a/src/interfaces/hostinterface.ts
+++ b/src/interfaces/hostinterface.ts
@@ -49,7 +49,8 @@ export interface HostInterface {
         filename: string,        // raw filename from directive
         from: NormalizedPath,   // path of current source file
         extensions: string[],    // possible extensions to try
-        includePaths?: string[]  // additional include paths from options
+        includePaths?: string[],  // additional include paths from options
+        unsafe?: boolean,
     ): Promise<NormalizedPath | null>;
 
     readFile(p: NormalizedPath, unsafe?: boolean): Promise<string | null>;

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -217,6 +217,7 @@ export const ErrorCodes = {
     INCLUDE_DEPTH_EXCEEDED: "INC003",
     PATH_RESOLUTION_FAILED: "INC004",
     FILE_READ_ERROR: "INC005",
+    INCLUDE_PATH_INVALID: "INC006",
 
     // Macro errors (MAC prefix)
     UNDEFINED_MACRO: "MAC001",

--- a/src/shared/includeprocessor.ts
+++ b/src/shared/includeprocessor.ts
@@ -31,6 +31,8 @@ export interface IncludeResult {
     resolvedPath: NormalizedPath | null;
     /** Error message if unsuccessful */
     error?: string;
+    /** Wether the file was included via an external alias */
+    external?: boolean;
 }
 
 export type LuauRCRequireMap = {[k:NormalizedPath]:RequireMap};
@@ -90,7 +92,8 @@ export class IncludeProcessor {
         _macros: MacroProcessor,
         _conditionals: ConditionalProcessor,
         diagnostics?: DiagnosticCollector,
-        column?: number
+        column?: number,
+        allowExternal: boolean = false,
     ): Promise<IncludeResult> {
         let filename = include.file;
         const line = include.line;
@@ -163,14 +166,14 @@ export class IncludeProcessor {
         } else {
             includePaths = [...(state.includePaths ?? [])];
         }
-
         let resolvedPath = await this.host.resolveFile(
             filename,
             sourceFile,
             extensions,
             includePaths,
-            aliased
+            aliased || allowExternal,
         );
+        console.error("Resolve: ", [filename, sourceFile, extensions, includePaths, aliased, allowExternal], resolvedPath);
 
         if(!resolvedPath && this.language == "luau") {
             // Luau require supports default file in folder include mechanic 'init.luau'
@@ -181,7 +184,7 @@ export class IncludeProcessor {
                     sourceFile,
                     extensions,
                     includePaths,
-                    aliased
+                    aliased || allowExternal,
                 );
             }
         }
@@ -275,7 +278,7 @@ export class IncludeProcessor {
         }
 
         // Read the include file
-        const includeContent = await this.host.readFile(resolvedPath, aliased);
+        const includeContent = await this.host.readFile(resolvedPath, aliased || allowExternal);
         if (!includeContent) {
             const error = `Failed to read include file: ${resolvedPath}`;
 
@@ -316,7 +319,8 @@ export class IncludeProcessor {
         return {
             success: true,
             tokens,
-            resolvedPath
+            resolvedPath,
+            external : aliased || allowExternal,
         };
     }
 

--- a/src/shared/includeprocessor.ts
+++ b/src/shared/includeprocessor.ts
@@ -10,13 +10,14 @@
  * - File resolution via HostInterface
  */
 
-import { NormalizedPath, HostInterface } from '../interfaces/hostinterface';
+import { NormalizedPath, HostInterface, normalizeJoinPath, normalizePath } from '../interfaces/hostinterface';
 import { ScriptLanguage } from './languageservice';
 import { Lexer, Token } from './lexer';
 import { MacroProcessor } from './macroprocessor';
 import { ConditionalProcessor } from './conditionalprocessor';
 import { DiagnosticCollector, DiagnosticSeverity, ErrorCodes } from './diagnostics';
 import { IncludeInfo } from './parser';
+import path from 'path';
 
 /**
  * Result of processing an include directive
@@ -32,6 +33,12 @@ export interface IncludeResult {
     error?: string;
 }
 
+export type LuauRCRequireMap = {[k:NormalizedPath]:RequireMap};
+export type RequireMap = {[k:string]:NormalizedPath};
+export type LuauRCFile = {
+    aliases: {[k:string]:string};
+};
+
 /**
  * State for include processing shared across nested includes
  */
@@ -46,6 +53,8 @@ export interface IncludeState {
     maxIncludeDepth: number;
     /** Include paths for file resolution */
     includePaths?: string[];
+    /** Require map for file resolution */
+    requireMap?: LuauRCRequireMap;
 }
 
 /**
@@ -83,7 +92,7 @@ export class IncludeProcessor {
         diagnostics?: DiagnosticCollector,
         column?: number
     ): Promise<IncludeResult> {
-        const filename = include.file;
+        let filename = include.file;
         const line = include.line;
         const isRequire = include.isRequire;
         // Check max include depth
@@ -113,14 +122,69 @@ export class IncludeProcessor {
 
         // Resolve the include file path
         const extensions = this.language === "lsl" ? ["lsl"] : ["luau", "lua"];
-        const includePaths = isRequire ? ["."] : (state.includePaths || ["."]);
+        let includePaths: string[] = [];
+        let aliased = false;
+        
+        if(isRequire) {
+            if(!filename.startsWith("@")) {
+                // Regular require, relative lookup
+                includePaths = ["."];
+            } else {
+                try {
+                    // get the alias path
+                    const aliasPath = await this.getLuauRequireAliasDir(filename, sourceFile, state);
+                    // Remove the alias from the filename
+                    filename = filename.split(path.sep).slice(1).join(path.sep);
+                    includePaths = [aliasPath];
+                    aliased = true;
+                } catch(error) {
+                    if(typeof(error) == "string") {
+                        if (diagnostics) {
+                            diagnostics.add({
+                                severity: DiagnosticSeverity.ERROR,
+                                code: ErrorCodes.FILE_NOT_FOUND,
+                                message: error,
+                                sourceFile: sourceFile,
+                                line: line ?? 0,
+                                column: column ?? 0,
+                                length: filename.length
+                            });
+                        }
+                        return {
+                            success: false,
+                            tokens: [],
+                            resolvedPath: null,
+                            error
+                        }
+                    }
+                    throw error;
+                }
+            }
+        } else {
+            includePaths = [...(state.includePaths ?? [])];
+        }
 
-        const resolvedPath = await this.host.resolveFile(
+        let resolvedPath = await this.host.resolveFile(
             filename,
             sourceFile,
             extensions,
-            includePaths
+            includePaths,
+            aliased
         );
+
+        if(!resolvedPath && this.language == "luau") {
+            // Luau require supports default file in folder include mechanic 'init.luau'
+            if(!filename.toLowerCase().endsWith(".luau") && !filename.toLocaleLowerCase().endsWith(".lua")) {
+                filename += (filename.length ? path.sep : "") + "init";
+                resolvedPath = await this.host.resolveFile(
+                    filename,
+                    sourceFile,
+                    extensions,
+                    includePaths,
+                    aliased
+                );
+            }
+        }
 
         if (!resolvedPath) {
             const error = `Include file not found: ${filename}`;
@@ -144,6 +208,33 @@ export class IncludeProcessor {
                 resolvedPath: null,
                 error
             };
+        }
+
+        if(aliased) {
+            // Check that the resolved path for an alias is definitley a child of the alias path.
+            const relative = path.relative(includePaths[0], resolvedPath);
+            if(!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+                const error = `Require file was not inside alias directory`;
+
+                if (diagnostics) {
+                    diagnostics.add({
+                        severity: DiagnosticSeverity.ERROR,
+                        code: ErrorCodes.INCLUDE_PATH_INVALID,
+                        message: error,
+                        sourceFile: sourceFile,
+                        line: line ?? 0,
+                        column: column ?? 0,
+                        length: filename.length
+                    });
+                }
+
+                return {
+                    success: false,
+                    tokens: [],
+                    resolvedPath: null,
+                    error
+                };
+            }
         }
 
         include.path = resolvedPath;
@@ -184,7 +275,7 @@ export class IncludeProcessor {
         }
 
         // Read the include file
-        const includeContent = await this.host.readFile(resolvedPath);
+        const includeContent = await this.host.readFile(resolvedPath, aliased);
         if (!includeContent) {
             const error = `Failed to read include file: ${resolvedPath}`;
 
@@ -229,6 +320,70 @@ export class IncludeProcessor {
         };
     }
 
+    private async getLuauRequireAliasDir(requirePath:string, sourceFile:NormalizedPath, state:IncludeState) : Promise<string> {
+        if(!requirePath.startsWith("@")) {
+            throw "Alias must start with @";
+        }
+        if(requirePath.endsWith(`${path.sep}..`) || requirePath.includes(`${path.sep}..${path.sep}`)) {
+            throw `Require alias cannot contain directory traversal`;
+        }
+
+        let alias = "";
+        let aliasLen = requirePath.split(path.sep)[0].length;
+        alias = requirePath.slice(1,aliasLen);
+        if(alias.startsWith("sl-")) {
+            // Reserve sl-* alias for possible future use as a standard library system
+            throw `Alias 'sl-*' is reserved`
+        }
+        
+        if(!state.requireMap) {
+            state.requireMap = {};
+        }
+        const map = await this.resolveLuaurcFileAliases(sourceFile, state.requireMap);
+
+        if(map[alias]) return map[alias];
+        
+        throw `Require alias not found: ${requirePath}`;
+    }
+
+    private async resolveLuaurcFileAliases(sourceFile:string, rcMap: LuauRCRequireMap) : Promise<RequireMap> {
+        const map: RequireMap = {};
+        let dir = normalizePath(sourceFile);
+        while(true) {
+            dir = normalizePath(path.dirname(dir));
+            if(dir.length < 3) break;
+            const norm = normalizeJoinPath(dir,".luaurc");
+            let dirMap = rcMap[norm] ?? null;
+            if(!dirMap) {
+                const rcfile = await this.host.readJSON<LuauRCFile>(norm);
+                if(rcfile === null) {
+                    rcMap[norm] = {};
+                    continue;
+                }
+                if(typeof(rcfile) !== "object") continue;
+                const aliases = rcfile.aliases ?? null;
+                if(typeof(aliases) !== "object") continue;
+                if(aliases === null) continue;
+                if(aliases instanceof Array) continue;
+                    rcMap[norm] = {};
+                for(const alias in aliases) {
+                    let str = aliases[alias];
+                    if(path.isAbsolute(str)) {
+                        rcMap[norm][alias] = normalizePath(str);
+                    } else {
+                        rcMap[norm][alias] = normalizeJoinPath(dir,str);
+                    }
+                }
+                dirMap = rcMap[norm] ?? {};
+            }
+            for(const alias in dirMap) {
+                map[alias] = dirMap[alias];
+            }
+        }
+
+        return map;
+    }
+
     /**
      * Create initial include state
      */
@@ -238,7 +393,7 @@ export class IncludeProcessor {
             includeStack: [],
             includeDepth: 0,
             maxIncludeDepth,
-            includePaths
+            includePaths,
         };
     }
 

--- a/src/shared/includeprocessor.ts
+++ b/src/shared/includeprocessor.ts
@@ -365,7 +365,7 @@ export class IncludeProcessor {
                 if(typeof(aliases) !== "object") continue;
                 if(aliases === null) continue;
                 if(aliases instanceof Array) continue;
-                    rcMap[norm] = {};
+                rcMap[norm] = {};
                 for(const alias in aliases) {
                     let str = aliases[alias];
                     if(path.isAbsolute(str)) {

--- a/src/shared/lexingpreprocessor.ts
+++ b/src/shared/lexingpreprocessor.ts
@@ -161,7 +161,7 @@ export class LexingPreprocessor {
                 this.fs,
                 predefinedMacros,
                 maxIncludeDepth,
-                includePaths
+                language == "lsl" ? includePaths : undefined
             );
 
             // Phase 2: Parsing and directive processing

--- a/src/shared/parser.ts
+++ b/src/shared/parser.ts
@@ -148,6 +148,9 @@ export class Parser {
     // Diagnostic collector
     private diagnostics: DiagnosticCollector;
 
+    // Flag wether external require is allowed, passed down when using .luarc
+    private allowExternalRequires: boolean = false;
+
     constructor(
         tokens: Token[],
         sourceFile: NormalizedPath,
@@ -1273,7 +1276,8 @@ export class Parser {
             this.state.macros,
             this.state.conditionals,
             this.diagnostics,
-            0  // column position
+            0,  // column position
+            this.allowExternalRequires,
         );
 
         if (!result.success) {
@@ -1321,6 +1325,8 @@ export class Parser {
                     false, // Nested parser is NOT top-level
                     this.workspaceRoots // Pass workspace roots to child parser
                 );
+                // Pass on this setting so that external files can perform requires
+                requireParser.allowExternalRequire(result.external ?? false);
 
                 // Parse the required file
                 const requireResult = await requireParser.parse();
@@ -1353,6 +1359,10 @@ export class Parser {
         // Emit the module invocation at the point of require()
         // __require_table[moduleId]()
         this.emitRequireInvocation(moduleId);
+    }
+
+    public allowExternalRequire(allow:boolean) : void {
+        this.allowExternalRequires = allow;
     }
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import * as vscode from "vscode";
 import path from "path";
 import { ConfigService } from "./configservice";
 import { ConfigKey, FullConfigInterface } from "./interfaces/configinterface";
-import { fileExists, HostInterface, NormalizedPath, normalizeJoinPath, normalizePath } from "./interfaces/hostinterface";
+import { fileExists, HostInterface, NormalizedPath, normalizePath } from "./interfaces/hostinterface";
 import { writeJSONFile, readJSONFile, writeYAMLFile, writeTOMLFile, readYAMLFile, readTOMLFile } from "./shared/sharedutils";
 
 // Generic utilities for sl-vscode-plugin

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,10 +3,10 @@
  * Copyright (C) 2025, Linden Research, Inc.
  */
 import * as vscode from "vscode";
-import * as path from "path";
+import path from "path";
 import { ConfigService } from "./configservice";
 import { ConfigKey, FullConfigInterface } from "./interfaces/configinterface";
-import { fileExists, HostInterface, NormalizedPath, normalizePath } from "./interfaces/hostinterface";
+import { fileExists, HostInterface, NormalizedPath, normalizeJoinPath, normalizePath } from "./interfaces/hostinterface";
 import { writeJSONFile, readJSONFile, writeYAMLFile, writeTOMLFile, readYAMLFile, readTOMLFile } from "./shared/sharedutils";
 
 // Generic utilities for sl-vscode-plugin
@@ -281,7 +281,8 @@ export class VSCodeHost implements HostInterface {
         filename: string,
         from: NormalizedPath,
         extensions: string[],
-        includePaths?: string[]
+        includePaths?: string[],
+        unsafe: boolean = false,
     ): Promise<NormalizedPath | null> {
         // Normalize base parameters
         const normalizedFrom = path.normalize(from);
@@ -306,7 +307,7 @@ export class VSCodeHost implements HostInterface {
 
         // Attempt to stat a candidate file
         const tryCandidate = async (absPath: string): Promise<string | null> => {
-            if (!isInsideWorkspace(absPath)) return null;
+            if (!isInsideWorkspace(absPath) && !unsafe) return null;
             try {
                 const uri = vscode.Uri.file(absPath);
                 const stat = await vscode.workspace.fs.stat(uri);


### PR DESCRIPTION
See #16 

Adds support for `require("@alias/...")` to slua pre processor by reading from `.luaurc` files within the workspace

 - this only reads `.luaurc` files within the workspace
   - externally included files, will not respect their own `.luaurc` files for now
 - prevents use for `..` for path traversal on an aliased require (just make a new alias)
 - reserves aliases prefixed with `sl-` for now, incase they may want to be used later.
 
This includes some basic documentation on it's use