### PR TITLE
Add extra filemeta to the output and support using it to match files

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,21 @@
             "type": "boolean",
             "default": false,
             "description": "Whether the plugin should fisrt check if there have been any actual changes on save, or to just send it to viewer anyway"
+          },
+          "slVscodeEdit.sync.includeFileMetaInOutput": {
+            "type": "boolean",
+            "default": false,
+            "description": "Wether the output script should include some meta information about the file"
+          },
+          "slVscodeEdit.sync.useFileMetaForMatching": {
+            "type": "boolean",
+            "default": false,
+            "description": "Wether the file matcher should use script meta info for matching file"
+          },
+          "slVscodeEdit.sync.includeCreatorInFileMeta": {
+            "type": "boolean",
+            "default": false,
+            "description": "Wether the current sl user info should be included in the meta info"
           }
         }
       },

--- a/src/interfaces/configinterface.ts
+++ b/src/interfaces/configinterface.ts
@@ -29,6 +29,10 @@ export enum ConfigKey {
   PreprocessorMaxIncludeDepth = 'preprocessor.maxIncludeDepth',
   LastSyntaxID = 'syntax.lastID',
   CompareHashBeforeSync = 'sync.compareHashBeforeSync',
+
+  FileMetaInfoInOutput ='sync.includeFileMetaInOutput',
+  FileMetaInfoUseForMatching ='sync.useFileMetaForMatching',
+  FileMetaInfoIncludeCreator ='sync.includeCreatorInFileMeta',
 }
 
 /** Scope target for configuration updates. */

--- a/src/scriptsync.ts
+++ b/src/scriptsync.ts
@@ -29,6 +29,7 @@ import { normalizePath } from "./interfaces/hostinterface";
 import { SynchService } from "./synchservice";
 import { IncludeInfo } from "./shared/parser";
 import { sha256 } from "js-sha256";
+import { LANGUAGE_CONFIGS } from "./shared/lexer";
 
 //====================================================================
 interface TrackedDocument {
@@ -433,6 +434,9 @@ export class ScriptSync implements vscode.Disposable {
             sha.update(finalContent);
             const hash = sha.hex();
 
+            console.error(finalContent, hash);
+            finalContent = this.prefixWithMetaInformation(finalContent, hash);
+
             // Walk through all TrackedDocuments and save their finalContents if the hash has changed
             await Promise.all(
                 this.getFileMappingsFilteredByHash(hash)
@@ -450,6 +454,34 @@ export class ScriptSync implements vscode.Disposable {
         } catch (err: any) {
             vscode.window.showErrorMessage(`Error syncing file: ${err.message}`);
         }
+    }
+
+    private prefixWithMetaInformation(content:string, hash: string) : string {
+        console.error("PREFIX ENABLED", this.config.getConfig<boolean>(ConfigKey.FileMetaInfoInOutput,false));
+        if(!this.config.getConfig<boolean>(ConfigKey.FileMetaInfoInOutput,false)) {
+            return content;
+        }
+        const meta : string[]= [];
+        const date = (new Date()).toISOString().split("T");
+
+        console.error("PREFIX")
+
+        const path = vscode.workspace.asRelativePath(this.masterDocument.uri.fsPath);
+
+        const comment =  LANGUAGE_CONFIGS[this.language].lineCommentPrefix;
+        meta.push(`${comment} ================ sl-vscode-plugin meta ================`);
+        meta.push(`${comment} @file ${path}`);
+        meta.push(`${comment} @hash ${hash}`);
+        meta.push(`${comment} @date ${date[0]} ${date[1].split(".")[0]}`);
+        console.error("PREFIX CREATOR", this.config.getConfig<boolean>(ConfigKey.FileMetaInfoIncludeCreator,false));
+        if(this.config.getConfig<boolean>(ConfigKey.FileMetaInfoIncludeCreator, false)) {
+            meta.push(`${comment} @creator ${ScriptSync.getCurrentAgentName()}`);
+            meta.push(`${comment} @creatorID ${ScriptSync.getCurrentAgentId()}`);
+        }
+        meta.push(`${comment} =======================================================`);
+        meta.push(content)
+
+        return meta.join("\n");
     }
 
     private getFileMappingsFilteredByHash(hash:string) : TrackedDocument[] {

--- a/src/shared/linemapper.ts
+++ b/src/shared/linemapper.ts
@@ -30,7 +30,7 @@ export class LineMapper {
                 // Extract the content after the directive prefix
                 const directiveContent = line.substring(commentPrefix.length).trim();
 
-                console.log(`Have @line directive: ${directiveContent}`)
+                // console.log(`Have @line directive: ${directiveContent}`)
                 // Parse line number and file path
                 // Expected format: "123 \"uri-or-path\""
                 const parts = directiveContent.split(' ');
@@ -47,12 +47,12 @@ export class LineMapper {
                 }
 
                 const sourceFileString = quotedMatch[1];
-                console.log(`quoted is: ${sourceFileString} `);
+                // console.log(`quoted is: ${sourceFileString} `);
                 const processedLine = i + 1; // Line numbers are 1-based
 
                 // Convert URI to filename using host interface
                 const sourceFileAbsolute: NormalizedPath = host.uriToFileName(sourceFileString);
-                console.log(`absolute is ${sourceFileAbsolute}`);
+                // console.log(`absolute is ${sourceFileAbsolute}`);
                 lineMappings.push({
                     processedLine: processedLine,
                     sourceFile: sourceFileAbsolute,

--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -31,8 +31,9 @@ import {
 import { maybe } from "./shared/sharedutils"; // TODO: migrate needed utilities from sharedutils if required
 import { ScriptLanguage, LanguageService } from "./shared/languageservice";
 import { ScriptSync } from "./scriptsync";
+import { LANGUAGE_CONFIGS } from "./shared/lexer";
 
-type ParsedTempFile = { scriptName: string; scriptId: string; extension: string };
+type ParsedTempFile = { scriptName: string; scriptId: string; extension: string, language: ScriptLanguage};
 
 export class SynchService implements vscode.Disposable {
     // Tracks all active sync relationships between temp files and master files
@@ -559,6 +560,7 @@ export class SynchService implements vscode.Disposable {
                 scriptName: match[1],
                 scriptId: match[2],
                 extension: match[3],
+                language: match[3].toLowerCase() == "lsl" ? "lsl" : "luau",
             }
             : null;
     }
@@ -600,12 +602,14 @@ export class SynchService implements vscode.Disposable {
     ): Promise<vscode.Uri | null> {
         // Attempt to match by file meta info
         if(ConfigService.getInstance().getConfig<boolean>(ConfigKey.FileMetaInfoUseForMatching, false)) {
-            const lineRegExp = new RegExp(/^--[\s]*@file[\s]*[A-z0-9-_/.]*$/,"i");
+            const cmt = LANGUAGE_CONFIGS[script.language].lineCommentPrefix;
+            const lineRegExp = new RegExp(`^[\\s]*${cmt}[\\s]*@file[\\s]*[A-z0-9-_/.]*[\\s]*$`,"i");
             const range = new vscode.Range(0,0,10,0);
             const start = viewerFile.getText(range).split("\n").filter(line => line.match(lineRegExp))[0] ?? null;
             if(start) {
                 const files = await vscode.workspace.findFiles(start.split("@file")[1].trim());
                 if(files.length == 1) {
+                    console.warn("Match on meta info");
                     return files[0];
                 }
             }

--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -170,7 +170,7 @@ export class SynchService implements vscode.Disposable {
         }
 
         // Look for a file in the workspace with the same name as the master script
-        let masterUri = await SynchService.findMasterFile(parsed);
+        let masterUri = await SynchService.findMasterFile(parsed, viewerDocument);
         if (!masterUri) {
             // There was no master file found, we are our own master
             showInfoMessage(
@@ -596,7 +596,21 @@ export class SynchService implements vscode.Disposable {
 
     private static async findMasterFile(
         script: ParsedTempFile,
+        viewerFile: vscode.TextDocument
     ): Promise<vscode.Uri | null> {
+        // Attempt to match by file meta info
+        if(ConfigService.getInstance().getConfig<boolean>(ConfigKey.FileMetaInfoUseForMatching, false)) {
+            const lineRegExp = new RegExp(/^--[\s]*@file[\s]*[A-z0-9-_/.]*$/,"i");
+            const range = new vscode.Range(0,0,10,0);
+            const start = viewerFile.getText(range).split("\n").filter(line => line.match(lineRegExp))[0] ?? null;
+            if(start) {
+                const files = await vscode.workspace.findFiles(start.split("@file")[1].trim());
+                if(files.length == 1) {
+                    return files[0];
+                }
+            }
+        }
+
         let files = await vscode.workspace.findFiles(`**/${script.scriptName}.${script.extension}`);
         if(files.length > 0) {
             return files[0];
@@ -614,8 +628,9 @@ export class SynchService implements vscode.Disposable {
                     relative = relative.slice(1);
                 }
                 const matches = [
-                    relative.replaceAll("/","").replaceAll("\\",""), // Try match `folder/script.luau` to `folderscript` or `folder/script` from sl
-                    relative.replaceAll("/","_").replaceAll("\\","_"), // Try to match `folder/script.luau` to `folder_script` from sl
+                    relative.replaceAll(path.sep,""), // Try match `folder/script.luau` to `folderscript` or `folder/script` from sl
+                    relative.replaceAll(path.sep,"_"), // Try to match `folder/script.luau` to `folder_script` from sl
+                    relative.replaceAll(path.sep," "), // Try to match `folder/script.luau` to `folder_script` from sl
                 ];
                 if(matches.includes(`${script.scriptName}.${script.extension}`)) {
                     return possibleFile;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -474,10 +474,10 @@ export class VSCodeHost implements HostInterface {
             }
 
             const absolutePath = path.join(folder.uri.fsPath, relativePath);
-            console.log(`uriToFileName: '${uri}' becomes '${absolutePath}'`);
+            // console.log(`uriToFileName: '${uri}' becomes '${absolutePath}'`);
             return normalizePath(absolutePath);
         }
-        console.log(`uriToFileName: ${uri}`)
+        // console.log(`uriToFileName: ${uri}`)
         // Handle standard file:// URLs
         return normalizePath(vscode.Uri.parse(uri).fsPath);
     }

--- a/src/websockclient.ts
+++ b/src/websockclient.ts
@@ -454,7 +454,7 @@ export class JSONRPCClient extends WebsockClient implements JSONRPCInterface {
     protected handleMessage(data: WebSocket.RawData): void {
         try {
             const message = JSON.parse(data.toString()) as JSONRPCMessage;
-            console.log("Received JSON-RPC message:", message);
+            // console.log("Received JSON-RPC message:", message);
 
             if (this.isJSONRPCResponse(message)) {
                 this.handleJSONRPCResponse(message);
@@ -533,10 +533,10 @@ export class JSONRPCClient extends WebsockClient implements JSONRPCInterface {
     }
 
     private handleJSONRPCNotification(notification: JSONRPCNotification): void {
-        console.log(
-            `JSON-RPC notification: ${notification.method}`,
-            notification.params,
-        );
+        // console.log(
+        //     `JSON-RPC notification: ${notification.method}`,
+        //     notification.params,
+        // );
 
         // Check for dynamically registered handlers
         const handler = this.methodHandlers.get(notification.method);
@@ -560,7 +560,7 @@ export class JSONRPCClient extends WebsockClient implements JSONRPCInterface {
     }
 
     private async handleJSONRPCRequest(request: JSONRPCRequest): Promise<void> {
-        console.log(`JSON-RPC request: ${request.method}`, request.params);
+        // console.log(`JSON-RPC request: ${request.method}`, request.params);
 
         // For requests, id should not be undefined, but we need to handle it safely
         const requestId = request.id !== undefined ? request.id : null;


### PR DESCRIPTION
All these features are disabled by default.

  - Adds option meta information to the output when a script is saved to sl
  - Adds option to include creator information in meta information header
  - Adds option to read this information when matching file in workspace
    - Allows for multiple scripts in 1 object to easily target the same source script (as they cannot be named the same)
    
  
###  Example output:
```luau
-- ================ sl-vscode-plugin meta ================
-- @file lox/interp.luau
-- @hash 0f2f377c7075d38906c2e92d21d14867cec4b66f129407bd977dc6f39e16cf0e
-- @date 2025-11-28 23:00:38
-- @creator WolfGang Senizen
-- @creatorID 677bf9a4-bba5-4cf9-a4ad-4802a0f7ef46
-- =======================================================
local __require_table: { [number]: () -> any } = {}
...
```

If the setting is enabled, on opening of a viewer temp file the extension will look for the `@file` hint near the top of the file, and use that to match to a workspace file. If none is found or it's ambiguous it falls back to the old method.

