### PR TITLE
Add support to lsl preprocessing for <> style includes

### DIFF
--- a/src/shared/parser.ts
+++ b/src/shared/parser.ts
@@ -401,7 +401,38 @@ export class Parser {
         }
 
         // PAR002: Check for missing filename argument
-        if (parser.isAtEnd() || parser.current().type === TokenType.NEWLINE || !parser.current().isString()) {
+        let filename:string|null = null;
+
+        if (!parser.isAtEnd()) {
+            const current = parser.current();
+            if (current.isString()) {
+                const fileToken = parser.current();
+                console.error("INCLUDE",token,fileToken);
+                filename = parser.extractStringValue(fileToken.value);
+            }
+            else if(current.type == TokenType.OPERATOR && current.value == "<") {
+                parser.advance();
+                let closed = false;
+                filename = "";
+                while(!parser.isAtEnd()) {
+                    const current = parser.current();
+                    if(current.type == TokenType.OPERATOR && current.value == ">") {
+                        closed = true;
+                        break;
+                    }
+                    if(current.type == TokenType.BLOCK_COMMENT_START) break;
+                    if(current.type == TokenType.LINE_COMMENT) break;
+                    if(current.type == TokenType.NEWLINE) break;
+                    filename += current.value;
+                    parser.advance();
+                }
+                if(!closed) {
+                    filename = null;
+                }
+            }
+        }
+
+        if(filename == null) {
             parser.diagnostics.addError(
                 '#include directive requires a filename argument',
                 {
@@ -414,9 +445,6 @@ export class Parser {
             );
             return;
         }
-
-        const fileToken = parser.current();
-        const filename = parser.extractStringValue(fileToken.value);
 
         // Record the include for tracking
         const include : IncludeInfo = {

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -807,6 +807,24 @@ integer x = 1;`;
         assert.strictEqual(result.includes[2].file, 'lib3.lsl');
     });
 
+    test('should detect <> style include', async () => {
+        const source = `#include <lib1.lsl>
+#include <lib2.lsl> // test
+#include <lib3.lsl>
+integer x = 1;`;
+
+        const lexer = new Lexer(source, 'lsl');
+        const tokens = lexer.tokenize();
+
+        const parser = new Parser(tokens, testFile, 'lsl');
+        const result = await parser.parse();
+
+        assert.strictEqual(result.includes.length, 3, 'Should detect 3 includes');
+        assert.strictEqual(result.includes[0].file, 'lib1.lsl');
+        assert.strictEqual(result.includes[1].file, 'lib2.lsl');
+        assert.strictEqual(result.includes[2].file, 'lib3.lsl');
+    });
+
     test('macro expansion in conditional block', async () => {
         const source = `#define DEBUG
 #define LOG(msg) llOwnerSay(msg)


### PR DESCRIPTION
The firestorm preproc supports includes with the following format

```c
#include <lib.lsl>
```

This pr adds support for that to allow for maximum compatibility with preexisting code.

Also includes test for said case.

Addresses part 1 of #32