### PR TITLE
LSL Preproc drop comments after defines

### DIFF
--- a/src/shared/parser.ts
+++ b/src/shared/parser.ts
@@ -487,9 +487,7 @@ export class Parser {
         parser.advance();
 
         // Skip only horizontal whitespace, not newlines
-        while (!parser.isAtEnd() && parser.current().type === TokenType.WHITESPACE) {
-            parser.advance();
-        }
+        parser.skipNonNewlineWhiteSpace();
 
         // PAR002: Check for missing macro name
         if (parser.isAtEnd() || parser.current().type === TokenType.NEWLINE) {
@@ -1080,6 +1078,12 @@ export class Parser {
         return tokens.slice(start, end);
     }
 
+    private skipNonNewlineWhiteSpace(): void {
+        while (!this.isAtEnd() && this.current().type == TokenType.WHITESPACE) {
+            this.advance();
+        }
+    }
+
     /**
      * Collect tokens for directive body (rest of line)
      * Supports line continuation with backslash (\)
@@ -1090,6 +1094,19 @@ export class Parser {
 
         while (!this.isAtEnd()) {
             const token = this.current();
+
+            if(token.type == TokenType.LINE_COMMENT) {
+                this.advance();
+                break;
+            }
+            if(token.type == TokenType.BLOCK_COMMENT_START) {
+                this.advance();
+                while(!this.isAtEnd() && this.current().type != TokenType.BLOCK_COMMENT_END) {
+                    this.advance();
+                }
+                this.advance();
+                break;
+            }
 
             // Check if token is or contains a newline
             const hasNewline = token.type === TokenType.NEWLINE || token.value.includes('\n');

--- a/src/test/suite/parser-directive-diagnostics.test.ts
+++ b/src/test/suite/parser-directive-diagnostics.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import { Parser } from '../../shared/parser';
-import { Lexer } from '../../shared/lexer';
+import { Lexer, TokenType } from '../../shared/lexer';
 import { DiagnosticCollector, DiagnosticSeverity, ErrorCodes } from '../../shared/diagnostics';
 import { normalizePath, NormalizedPath } from '../../interfaces/hostinterface';
 
@@ -350,6 +350,35 @@ float area = PI * radius * radius;
                 d.code?.startsWith('PAR')
             );
             assert.strictEqual(parserErrors.length, 0, 'Should not have any parser errors');
+        });
+
+        test('check correct value capture for #define', async () => {
+            const source = `#define A 1
+#define B 2 // Comment
+#define C 3`;
+            const diagnostics = new DiagnosticCollector();
+            const lexer = new Lexer(source, 'lsl', sourceFile, diagnostics);
+            const tokens = lexer.tokenize();
+            const parser = new Parser(tokens, sourceFile, 'lsl', undefined, undefined, undefined, true, undefined, diagnostics);
+
+            await parser.parse();
+
+            const parserErrors = diagnostics.getAll().filter(d =>
+                d.code?.startsWith('PAR')
+            );
+            assert.strictEqual(parserErrors.length, 0, 'Should not have any parser errors');
+
+            assert.strictEqual(parser.getState().macros.getMacro("A")?.body.length,1);
+            assert.strictEqual(parser.getState().macros.getMacro("A")?.body[0].type,TokenType.NUMBER_LITERAL);
+            assert.strictEqual(parser.getState().macros.getMacro("A")?.body[0].value,"1");
+
+            assert.strictEqual(parser.getState().macros.getMacro("B")?.body.length,1);
+            assert.strictEqual(parser.getState().macros.getMacro("B")?.body[0].type,TokenType.NUMBER_LITERAL);
+            assert.strictEqual(parser.getState().macros.getMacro("B")?.body[0].value,"2");
+
+            assert.strictEqual(parser.getState().macros.getMacro("C")?.body.length,1);
+            assert.strictEqual(parser.getState().macros.getMacro("C")?.body[0].type,TokenType.NUMBER_LITERAL);
+            assert.strictEqual(parser.getState().macros.getMacro("C")?.body[0].value,"3");
         });
     });
 });


### PR DESCRIPTION
Currently this

```LSL
#define TEXT "text" // Comment
default {
    state_entry() {
        llOwnerSay(TEXT);
    }
}
```

Outputs this invalid code

```LSL
#define TEXT 
default {
    state_entry() {
        llOwnerSay("text" // Comment);
    }
}
```


This pr alters the behavior of the parser to drop comments when building the body of a define

Includes test for the same

Addresses part 2 of #32