### PR TITLE
Add support for alternative LLEvents event subscription style

### DIFF
--- a/data/dev/sl-lua-defs.json
+++ b/data/dev/sl-lua-defs.json
@@ -91,6 +91,438 @@
       "name": "LLEventsProto",
       "definition": {
         "kind": "table",
+        "properties": [
+          {
+            "name": "touch_start",
+            "type": {
+              "kind": "union",
+              "types": [
+                "DetectedEventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "touch",
+            "type": {
+              "kind": "union",
+              "types": [
+                "DetectedEventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "touch_end",
+            "type": {
+              "kind": "union",
+              "types": [
+                "DetectedEventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "collision_start",
+            "type": {
+              "kind": "union",
+              "types": [
+                "DetectedEventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "collision",
+            "type": {
+              "kind": "union",
+              "types": [
+                "DetectedEventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "collision_end",
+            "type": {
+              "kind": "union",
+              "types": [
+                "DetectedEventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "sensor",
+            "type": {
+              "kind": "union",
+              "types": [
+                "DetectedEventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "on_damage",
+            "type": {
+              "kind": "union",
+              "types": [
+                "DetectedEventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "final_damage",
+            "type": {
+              "kind": "union",
+              "types": [
+                "DetectedEventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "at_rot_target",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "at_target",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "attach",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "changed",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "control",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "dataserver",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "email",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "experience_permissions",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "experience_permissions_denied",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "game_control",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "http_request",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "http_response",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "land_collision",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "land_collision_end",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "land_collision_start",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "link_message",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "linkset_data",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "listen",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "money",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "moving_end",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "moving_start",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "no_sensor",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "not_at_rot_target",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "not_at_target",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "object_rez",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "on_death",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "on_rez",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "path_update",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "remote_data",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "run_time_permissions",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "state_entry",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "state_exit",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "timer",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          },
+          {
+            "name": "transaction_result",
+            "type": {
+              "kind": "union",
+              "types": [
+                "EventHandler",
+                "nil"
+              ]
+            }
+          }
+        ],
         "methods": [
           {
             "name": "eventNames",
@@ -587,6 +1019,21 @@
       "name": "LLTimers",
       "type": "LLTimersProto",
       "comment": "LLTimers object"
+    },
+    {
+      "comment": "loadstring is removed in slua",
+      "name": "loadstring",
+      "type": "nil"
+    },
+    {
+      "comment": "getfenv is removed in slua",
+      "name": "getfenv",
+      "type": "nil"
+    },
+    {
+      "comment": "setfenv is removed in slua",
+      "name": "setfenv",
+      "type": "nil"
     }
   ],
   "globalFunctions": [

--- a/data/syntax_def_default.json
+++ b/data/syntax_def_default.json
@@ -15527,6 +15527,21 @@
         "comment": "LLTimers object",
         "name": "LLTimers",
         "type": "LLTimersProto"
+      },
+      {
+        "comment": "loadstring is removed in slua",
+        "name": "loadstring",
+        "type": "nil"
+      },
+      {
+        "comment": "getfenv is removed in slua",
+        "name": "getfenv",
+        "type": "nil"
+      },
+      {
+        "comment": "setfenv is removed in slua",
+        "name": "setfenv",
+        "type": "nil"
       }
     ],
     "modules": [
@@ -16206,6 +16221,438 @@
       {
         "definition": {
           "kind": "table",
+          "properties": [
+            {
+              "name": "touch_start",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "DetectedEventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "touch",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "DetectedEventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "touch_end",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "DetectedEventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "collision_start",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "DetectedEventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "collision",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "DetectedEventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "collision_end",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "DetectedEventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "sensor",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "DetectedEventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "on_damage",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "DetectedEventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "final_damage",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "DetectedEventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "at_rot_target",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "at_target",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "attach",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "changed",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "control",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "dataserver",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "email",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "experience_permissions",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "experience_permissions_denied",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "game_control",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "http_request",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "http_response",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "land_collision",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "land_collision_end",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "land_collision_start",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "link_message",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "linkset_data",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "listen",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "money",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "moving_end",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "moving_start",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "no_sensor",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "not_at_rot_target",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "not_at_target",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "object_rez",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "on_death",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "on_rez",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "path_update",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "remote_data",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "run_time_permissions",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "state_entry",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "state_exit",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "timer",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            },
+            {
+              "name": "transaction_result",
+              "type": {
+                "kind": "union",
+                "types": [
+                  "EventHandler",
+                  "nil"
+                ]
+              }
+            }
+          ],
           "methods": [
             {
               "name": "eventNames",

--- a/src/pluginsupport.ts
+++ b/src/pluginsupport.ts
@@ -180,9 +180,16 @@ export class LuaLSPPlugin extends BasePlugin {
             // Discard array config, theres not much else we can do to fix it
             luaulspDefs = {}
         }
-        luaulspDefs["sl-slua"] = defsFile;
+        const newDefs : {[k:string]:string} = {};
+        for(const defKey in luaulspDefs) {
+            if(!defKey.startsWith("sl-")) {
+                console.error("DEF",defKey);
+                newDefs[defKey] = luaulspDefs[defKey];
+            }
+        }
+        newDefs["sl-slua"] = defsFile;
 
-        await luaulsp.update("types.definitionFiles", luaulspDefs);
+        await luaulsp.update("types.definitionFiles", newDefs);
         await luaulsp.update("types.documentationFiles", [docsFile]);
         await luaulsp.update("platform.type", "standard");
         await luaulsp.update("sourcemap.enabled", false);

--- a/src/shared/docsjsongenerator.ts
+++ b/src/shared/docsjsongenerator.ts
@@ -24,6 +24,8 @@ interface DocDatabase {
     [key: string]: DocEntry;
 }
 
+const globalsPrefix = `@sl-slua/global/`
+
 /**
  * Generates docs.json file from Lua type definitions
  */
@@ -62,7 +64,7 @@ export class DocsJsonGenerator {
      * Add global function documentation
      */
     private addGlobalFunction(func: GlobalFunction, docs: DocDatabase): void {
-        const key = `@roblox/global/${func.name}`;
+        const key = `${globalsPrefix}${func.name}`;
 
         const entry: DocEntry = {
             documentation: this.formatDocumentation(func.comment || `${func.name} function`)
@@ -81,7 +83,7 @@ export class DocsJsonGenerator {
      */
     private addModule(module: ModuleDeclaration, docs: DocDatabase): void {
         // Add module itself
-        const moduleKey = `@roblox/global/${module.name}`;
+        const moduleKey = `${globalsPrefix}${module.name}`;
         docs[moduleKey] = {
             documentation: module.comment || `${module.name} module`,
             summary: module.comment || `${module.name} module`
@@ -110,7 +112,7 @@ export class DocsJsonGenerator {
      * Add module property documentation
      */
     private addModuleProperty(moduleName: string, prop: ModuleProperty, docs: DocDatabase): void {
-        const key = `@roblox/global/${moduleName}.${prop.name}`;
+        const key = `${globalsPrefix}${moduleName}.${prop.name}`;
 
         const entry: DocEntry = {
             documentation: this.formatDocumentation(prop.comment || `${moduleName}.${prop.name} property`)
@@ -128,7 +130,7 @@ export class DocsJsonGenerator {
      * Add module function documentation
      */
     private addModuleFunction(moduleName: string, func: FunctionSignature, docs: DocDatabase): void {
-        const key = `@roblox/global/${moduleName}.${func.name}`;
+        const key = `${globalsPrefix}${moduleName}.${func.name}`;
 
         const entry: DocEntry = {
             documentation: this.formatDocumentation(func.comment || `${moduleName}.${func.name} function`)
@@ -146,7 +148,7 @@ export class DocsJsonGenerator {
      * Add constant documentation
      */
     private addConstant(constant: ConstantDeclaration, docs: DocDatabase): void {
-        const key = `@roblox/global/${constant.name}`;
+        const key = `${globalsPrefix}${constant.name}`;
 
         const entry: DocEntry = {
             documentation: this.formatDocumentation(constant.comment || `${constant.name} constant`)

--- a/src/test/suite/selene-config.test.ts
+++ b/src/test/suite/selene-config.test.ts
@@ -297,8 +297,8 @@ suite('LuauDefsGenerator and DocsJsonGenerator Tests', () => {
         assert.ok(result.includes('declare function tovector'), 'Should generate tovector function');
 
         // Check documentation
-        assert.ok(docs['@roblox/global/toquaternion'], 'Should have toquaternion documentation');
-        assert.ok(docs['@roblox/global/tovector'], 'Should have tovector documentation');
+        assert.ok(docs['@sl-slua/global/toquaternion'], 'Should have toquaternion documentation');
+        assert.ok(docs['@sl-slua/global/tovector'], 'Should have tovector documentation');
     });
 
     test('Should handle constants correctly', () => {
@@ -344,10 +344,10 @@ suite('LuauDefsGenerator and DocsJsonGenerator Tests', () => {
         assert.ok(result.includes('declare EMPTY_STRING'), 'Should generate EMPTY_STRING constant');
 
         // Check documentation
-        assert.ok(docs['@roblox/global/TRUE'], 'Should have TRUE constant documentation');
-        assert.ok(docs['@roblox/global/FALSE'], 'Should have FALSE constant documentation');
-        assert.ok(docs['@roblox/global/PI'], 'Should have PI constant documentation');
-        assert.ok(docs['@roblox/global/EMPTY_STRING'], 'Should have EMPTY_STRING constant documentation');
+        assert.ok(docs['@sl-slua/global/TRUE'], 'Should have TRUE constant documentation');
+        assert.ok(docs['@sl-slua/global/FALSE'], 'Should have FALSE constant documentation');
+        assert.ok(docs['@sl-slua/global/PI'], 'Should have PI constant documentation');
+        assert.ok(docs['@sl-slua/global/EMPTY_STRING'], 'Should have EMPTY_STRING constant documentation');
     });
 
     test('Should handle function parameters with optional and variadic types', () => {
@@ -483,8 +483,8 @@ suite('LuauDefsGenerator and DocsJsonGenerator Tests', () => {
 
         // Should have comprehensive documentation
         assert.ok(Object.keys(docs).length >= 2, 'Should have multiple documentation entries');
-        assert.ok(docs['@roblox/global/globalHelper'], 'Should have global function docs');
-        assert.ok(docs['@roblox/global/MAX_VALUE'], 'Should have constant docs');
+        assert.ok(docs['@sl-slua/global/globalHelper'], 'Should have global function docs');
+        assert.ok(docs['@sl-slua/global/MAX_VALUE'], 'Should have constant docs');
     });
 
     test('Should handle empty definitions gracefully', () => {


### PR DESCRIPTION
This adds support for the alternate style of subscribing to events on `LLEvents`

```luau
function LLEvents.touch_start(detected: {DetectedEvent})
    -- code...
end
```

Several people have been following the examples on the create wiki and wondering why vscode is complaining about them

(also fixes the generated luau docs files, as they were not being used, since luau-lsp changed how loading them works)