### PR TITLE
Delay initial definition generation to opening of first luau file

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ end
 
 ## Configuration
 
+### Only use plugin in specific workspaces
+
+The plugin can be configured to only run inside specific workspaces, instead of globally.
+
+To do this, go to `settings` > `extienstions` and find the SL Scipting settings,
+and uncheck the `Enabled` setting.
+
+Then in any workspace you want to use the plugin in, you can either manually set the
+`Enabled` setting at the workspace level, or open the command pallete and run the
+`Second Life: Enable Extension for Workspace` command.
+
 ### Preprocessor Settings
 
 Configure preprocessing behavior in VS Code settings:

--- a/src/interfaces/hostinterface.ts
+++ b/src/interfaces/hostinterface.ts
@@ -44,6 +44,9 @@ export function splitFilename(filename: NormalizedPath): { basepath: string; fil
 export interface HostInterface {
     /** Central configuration provider (framework-agnostic). */
     config: FullConfigInterface;
+
+    existsInSameWorkspace(knownPath:string, desiredPath:string): Promise<boolean>;
+
     exists(p: NormalizedPath, unsafe?: boolean): Promise<boolean>;
     resolveFile(
         filename: string,        // raw filename from directive

--- a/src/pluginsupport.ts
+++ b/src/pluginsupport.ts
@@ -186,7 +186,7 @@ export class LuaLSPPlugin extends BasePlugin {
         await luaulsp.update("types.documentationFiles", [docsFile]);
         await luaulsp.update("platform.type", "standard");
         await luaulsp.update("sourcemap.enabled", false);
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        await new Promise((resolve) => setTimeout(resolve, 1000));
         // Execute luau-lsp's command to realod the language sever
         await vscode.commands.executeCommand("luau-lsp.reloadServer")
     }

--- a/src/scriptsync.ts
+++ b/src/scriptsync.ts
@@ -25,7 +25,7 @@ import {
 } from "./utils";
 import { ScriptLanguage } from "./shared/languageservice";
 import { CompilationResult, RuntimeDebug, RuntimeError } from "./viewereditwsclient";
-import { normalizePath } from "./interfaces/hostinterface";
+import { HostInterface, normalizePath } from "./interfaces/hostinterface";
 import { SynchService } from "./synchservice";
 import { IncludeInfo } from "./shared/parser";
 import { sha256 } from "js-sha256";
@@ -51,6 +51,7 @@ export class ScriptSync implements vscode.Disposable {
     private diagnosticSources: Set<string> = new Set();
     private lineMappings?: LineMapping[];
     private config: ConfigService;
+    private host: HostInterface;
 
     private includedFiles : IncludeInfo[] = [];
 
@@ -61,6 +62,7 @@ export class ScriptSync implements vscode.Disposable {
         config: ConfigService,
         scriptId?: string,
         viewerDocument?: vscode.TextDocument,
+        host?: HostInterface,
     ) {
         this.config = config;
 
@@ -69,10 +71,12 @@ export class ScriptSync implements vscode.Disposable {
         this.macros = new MacroProcessor(this.language);
         this.initializeSystemMacros(language);
 
+        this.host = host ?? new VSCodeHost();
+
         // Initialize preprocessor with macro processor
         const enabled = config.getConfig<boolean>(ConfigKey.PreprocessorEnable) ?? true;
         if (enabled) {
-            this.preprocessor = new LexingPreprocessor(new VSCodeHost(), config, this.macros);
+            this.preprocessor = new LexingPreprocessor(this.host, config, this.macros);
         }
 
         this.masterDocument = masterDocument;

--- a/src/server/nodehost.ts
+++ b/src/server/nodehost.ts
@@ -57,6 +57,10 @@ export class NodeHost implements HostInterface {
         };
     }
 
+    existsInSameWorkspace(_knownPath: string, _desiredPath: string): Promise<boolean> {
+        throw new Error('Method not implemented.');
+    }
+
     // ---------------------------------------------------------------------
     async exists(p: NormalizedPath, _unsafe?: boolean): Promise<boolean> {
         try {

--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -27,11 +27,13 @@ import {
     showWarningMessage,
     closeEditor,
     logInfo,
+    VSCodeHost,
 } from "./utils";
 import { maybe } from "./shared/sharedutils"; // TODO: migrate needed utilities from sharedutils if required
 import { ScriptLanguage, LanguageService } from "./shared/languageservice";
 import { ScriptSync } from "./scriptsync";
 import { LANGUAGE_CONFIGS } from "./shared/lexer";
+import { HostInterface } from "./interfaces/hostinterface";
 
 type ParsedTempFile = { scriptName: string; scriptId: string; extension: string, language: ScriptLanguage};
 
@@ -45,6 +47,8 @@ export class SynchService implements vscode.Disposable {
     private handshakePromise?: Promise<{ success: boolean; message: string }>;
     private lastActiveChange: number = 0;
     private activeSync: ScriptSync | undefined;
+    private host: HostInterface;
+    private initialGenerationDone: boolean = false;
 
     public viewerName?: string;
     public viewerVersion?: string;
@@ -58,6 +62,7 @@ export class SynchService implements vscode.Disposable {
 
     private constructor(context: vscode.ExtensionContext) {
         this.context = context;
+        this.host = new VSCodeHost();
     }
 
     public static getInstance(context?: vscode.ExtensionContext): SynchService {
@@ -115,8 +120,6 @@ export class SynchService implements vscode.Disposable {
             (editor: vscode.TextEditor | undefined) =>
                 this.onChangeActiveTextEditor(editor),
         );
-
-        this.initializeSyntax();
 
         // TODO: Figure out why restart isn't working on the luau-lsp server
         // TODO: Bug when prepping language syntax on download
@@ -217,6 +220,7 @@ export class SynchService implements vscode.Disposable {
                 config,
                 parsed.scriptId,
                 viewerDocument,
+                this.host,
             );
             this.activeSyncs.set(masterPath, sync);
         }
@@ -662,7 +666,15 @@ export class SynchService implements vscode.Disposable {
     //#region Event handlers
     private async onOpenTextDocument(document: vscode.TextDocument): Promise<void> {
         this.lastActiveChange = 0;
+        this.initialDefinitionGeneration(document);
         await this.setupSync(document);
+    }
+
+    private async initialDefinitionGeneration(document: vscode.TextDocument) : Promise<void> {
+        if(this.initialGenerationDone) return;
+        if(!document.uri.fsPath.endsWith(".luau")) return;
+        this.initialGenerationDone = true;
+        this.initializeSyntax();
     }
 
     private onCloseTextDocument(document: vscode.TextDocument): void {

--- a/src/test/suite/diagnostic-integration.test.ts
+++ b/src/test/suite/diagnostic-integration.test.ts
@@ -152,6 +152,9 @@ function createMockHostWithFiles(files: Map<string, string>, options?: Preproces
         async writeTOML(p: NormalizedPath, data: Record<string, any>): Promise<boolean> {
             return false;
         },
+        async existsInSameWorkspace(knownPath: string, desiredPath: string): Promise<boolean> {
+            return false;
+        },
         fileNameToUri(fileName: NormalizedPath): string {
             // Strip path to only include directories/filename after "test" directory
             const testIndex = fileName.indexOf('test');

--- a/src/test/suite/include-disk-integration.test.ts
+++ b/src/test/suite/include-disk-integration.test.ts
@@ -136,6 +136,10 @@ class DiskTestHost implements HostInterface {
         return null;
     }
 
+    async existsInSameWorkspace(knownPath: string, desiredPath: string): Promise<boolean> {
+        return false;
+    }
+
     async readYAML<T = any>(p: NormalizedPath): Promise<T | null> {
         return null;
     }

--- a/src/test/suite/lexingpreprocessor.test.ts
+++ b/src/test/suite/lexingpreprocessor.test.ts
@@ -120,6 +120,9 @@ suite("Lexing Preprocessor Test Suite", () => {
             async writeTOML(p: NormalizedPath, data: Record<string, any>): Promise<boolean> {
                 return false;
             }
+            async existsInSameWorkspace(knownPath: string, desiredPath: string): Promise<boolean> {
+                return false;
+            }
             fileNameToUri(fileName: NormalizedPath): string {
                 // Strip path to only include directories/filename after "test" directory
                 const testIndex = fileName.indexOf('test');
@@ -181,6 +184,9 @@ suite("Lexing Preprocessor Test Suite", () => {
                 return false;
             }
             async writeTOML(p: NormalizedPath, data: Record<string, any>): Promise<boolean> {
+                return false;
+            }
+            async existsInSameWorkspace(knownPath: string, desiredPath: string): Promise<boolean> {
                 return false;
             }
             fileNameToUri(fileName: NormalizedPath): string {

--- a/src/test/suite/parse-line-mappings.test.ts
+++ b/src/test/suite/parse-line-mappings.test.ts
@@ -53,6 +53,9 @@ suite('Parse Line Mappings Tests', () => {
             async writeTOML(p: NormalizedPath, data: Record<string, any>): Promise<boolean> {
                 return false;
             }
+            async existsInSameWorkspace(knownPath: string, desiredPath: string): Promise<boolean> {
+                return false;
+            }
             fileNameToUri(fileName: NormalizedPath): string {
                 // Strip path to only include directories/filename after "test" directory
                 const testIndex = fileName.indexOf('test');

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -52,6 +52,9 @@ suite('Parser Tests', () => {
             async writeTOML(p: NormalizedPath, data: Record<string, any>): Promise<boolean> {
                 return false;
             }
+            async existsInSameWorkspace(knownPath: string, desiredPath: string): Promise<boolean> {
+                return false;
+            }
             fileNameToUri(fileName: NormalizedPath): string {
                 // Strip path to only include directories/filename after "test" directory
                 const testIndex = fileName.indexOf('test');

--- a/src/test/suite/require-table.test.ts
+++ b/src/test/suite/require-table.test.ts
@@ -14,7 +14,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 import { Parser } from '../../shared/parser';
 import { Lexer } from '../../shared/lexer';
-import { NormalizedPath, normalizePath } from '../../interfaces/hostinterface';
+import { HostInterface, NormalizedPath, normalizePath } from '../../interfaces/hostinterface';
 
 suite('Require Table Tests', () => {
     const testFile = normalizePath('/test/main.luau');
@@ -375,7 +375,7 @@ suite('Require Table Tests', () => {
             const fileD = normalizePath(path.join(workspaceRoot, 'complex_d.luau'));
 
             // Create a hybrid host that uses in-memory files
-            const memoryHost = {
+            const memoryHost : HostInterface = {
                 config: {} as any,
                 readFile: async (p: NormalizedPath): Promise<string | null> => {
                     return files.get(p) || null;
@@ -400,6 +400,7 @@ suite('Require Table Tests', () => {
                 readTOML: async (): Promise<any> => null,
                 writeYAML: async (): Promise<boolean> => true,
                 writeTOML: async (): Promise<boolean> => true,
+                existsInSameWorkspace: async (knownPath: string, desiredPath: string): Promise<boolean> => false,
                 fileNameToUri: (fileName: NormalizedPath): string => {
                     // Strip path to only include directories/filename after "test" directory
                     const testIndex = fileName.indexOf('test');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -250,6 +250,16 @@ export class VSCodeHost implements HostInterface {
         return (await readTOMLFile(p)) as T | null;
     }
 
+    async existsInSameWorkspace(knownPath: string, desiredPath: string): Promise<boolean> {
+        const knownUri = vscode.Uri.file(normalizePath(knownPath));
+        const workspaceDir = vscode.workspace.getWorkspaceFolder(knownUri);
+        if(!workspaceDir) return false;
+        const desiredUri = vscode.Uri.file(normalizePath(workspaceDir.uri.fsPath + path.sep + desiredPath));
+        const dWorkspaceDir = vscode.workspace.getWorkspaceFolder(desiredUri);
+        if(!dWorkspaceDir) return false;
+        return dWorkspaceDir.uri.fsPath == workspaceDir.uri.fsPath;
+    }
+
     async exists(filename: NormalizedPath, unsafe?: boolean): Promise<boolean> {
         if (unsafe) {
             return await fileExists(filename);


### PR DESCRIPTION
Addresses #25

This delays the generation of language specific files  till the first `.luau` file is opened.

For now I have let `selene.toml` generate along with the rest, as the user has to have the extension installed.

It also give the luau lsp a little more time to restart, making sure it properly catches the file changes so that it can start processing.

Also included some documentation on running the extension disabled by default.