### PR TITLE
Add support for preproc style macro's as system constants

### DIFF
--- a/doc/preprocessor-guide.md
+++ b/doc/preprocessor-guide.md
@@ -409,19 +409,19 @@ The preprocessor supports C-style `#define` directives for creating reusable con
 
 The preprocessor automatically defines the following system macros that are available in all scripts:
 
-| Macro | Description | Example Value |
-|-------|-------------|---------------|
-| `__AGENTID__` | Agent UUID (formatted) | `"550e8400-e29b-41d4-a716-446655440000"` |
-| `__AGENTIDRAW__` | Raw agent ID format (not stringized) | `550e8400e29b41d4a716446655440000` |
-| `__AGENTKEY__` | Alternate name for `__AGENTID__` | `"550e8400-e29b-41d4-a716-446655440000"` |
-| `__AGENTNAME__` | Agent display name | `"Resident Name"` |
-| `__DATE__` | Current date (ISO format) | `"2025-11-18"` |
-| `__FILE__` | Full path/name of current file being processed | `"scripts/main.lsl"` |
-| `__LINE__` | Current line number being processed | `42` |
-| `__SHORTFILE__` | Short filename without path | `"main.lsl"` |
-| `__TIME__` | Current time (ISO format) | `"14:30:45"` |
-| `__TIMESTAMP__` | Full ISO timestamp | `"2025-11-18T14:30:45.123Z"` |
-| `__UNIXTIME__` | Unix timestamp timestamp as an integer | `1763751286` |
+| Macro | Description | Example Value | LSL | SLua |
+|-------|-------------|---------------| --- | ---- |
+| `__AGENTID__` | Agent UUID (formatted) | `"550e8400-e29b-41d4-a716-446655440000"` | ✔️ | ✔️ |
+| `__AGENTIDRAW__` | Raw agent ID format (not stringized) | `550e8400e29b41d4a716446655440000` | ✔️ | ❌ |
+| `__AGENTKEY__` | Alternate name for `__AGENTID__` | LSL : `"550e8400-e29b-41d4-a716-446655440000"`<br>SLua: `uuid("550e8400-e29b-41d4-a716-446655440000")` | ✔️ | ✔️ |
+| `__AGENTNAME__` | Agent display name | `"Resident Name"` | ✔️ | ✔️ |
+| `__DATE__` | Current date (ISO format) | `"2025-11-18"` | ✔️ | ✔️ |
+| `__FILE__` | Full path/name of current file being processed | `"scripts/main.lsl"` | ✔️ | ✔️ |
+| `__LINE__` | Current line number being processed | `42` | ✔️ | ✔️ |
+| `__SHORTFILE__` | Short filename without path | `"main.lsl"` | ✔️ | ✔️ |
+| `__TIME__` | Current time (ISO format) | `"14:30:45"` | ✔️ | ✔️ |
+| `__TIMESTAMP__` | Full ISO timestamp | `"2025-11-18T14:30:45.123Z"` | ✔️ | ✔️ |
+| `__UNIXTIME__` | Unix timestamp timestamp as an integer | `1763751286` | ✔️ | ✔️ |
 
 **Usage Example:**
 
@@ -433,6 +433,12 @@ default {
         llOwnerSay("Running on line " + (string)__LINE__);
     }
 }
+```
+
+```luau
+ll.OwnerSay("Script: " .. __SHORTFILE__ .. " (Agent: " .. __AGENTNAME__ .. ")");
+ll.OwnerSay("Compiled on " .. __DATE__ .. " at " .. __TIME__);
+ll.OwnerSay("Running on line " .. __LINE__);
 ```
 
 ### Simple Defines

--- a/package.json
+++ b/package.json
@@ -132,6 +132,12 @@
             "minimum": 1,
             "maximum": 50,
             "description": "Maximum nesting depth for #include and require() directives"
+          },
+          "slVscodeEdit.preprocessor.constantsInSLua": {
+            "title": "Use constants in SLua",
+            "type": "boolean",
+            "default": false,
+            "description": "Enable predefined LSL stlye preproc macro constants in slua"
           }
         }
       },

--- a/src/interfaces/configinterface.ts
+++ b/src/interfaces/configinterface.ts
@@ -27,6 +27,7 @@ export enum ConfigKey {
   PreprocessorOptions = 'preprocessor.options',
   PreprocessorIncludePaths = 'preprocessor.includePaths',
   PreprocessorMaxIncludeDepth = 'preprocessor.maxIncludeDepth',
+  PreprocessorConstantsInSLua = 'preprocessor.constantsInSLua',
   LastSyntaxID = 'syntax.lastID',
   CompareHashBeforeSync = 'sync.compareHashBeforeSync',
 

--- a/src/pluginsupport.ts
+++ b/src/pluginsupport.ts
@@ -9,6 +9,7 @@ import { LuaTypeDefinitions } from "./shared/luadefsinterface";
 import { LuauDefsGenerator } from "./shared/luadefsgenerator";
 import { DocsJsonGenerator } from "./shared/docsjsongenerator";
 import { SeleneYamlGenerator } from "./shared/seleneyamlgenerator";
+import { ConfigKey } from "./interfaces/configinterface";
 
 //=============================================================================
 abstract class BasePlugin {
@@ -148,23 +149,31 @@ export class LuaLSPPlugin extends BasePlugin {
         let configPath: NormalizedPath;
         configPath = await this.host.config.getWorkspaceConfigPath();
 
-        const defsFileName = await this.saveLuauLSPDefs(
+        const defsFiles:{[k:string]:string} = {};
+
+        defsFiles["sl-slua"] = await this.saveLuauLSPDefs(
             configPath,
             version,
             configs[0],
         );
+        console.error("SLUA PRE PROC CONSTANTS",this.host.config.getConfig(ConfigKey.PreprocessorConstantsInSLua, false));
+        if(this.host.config.getConfig(ConfigKey.PreprocessorConstantsInSLua, false)) {
+            defsFiles["sl-slua-consts"] = await this.saveLuauLSPConstantDefs(
+                configPath
+            );
+        }
         const docsFileName = await this.saveLuauLSPDocs(
             configPath,
             version,
             configs[1],
         );
 
-        await this.restartLuauLSP(defsFileName, docsFileName, this.host);
+        await this.restartLuauLSP(defsFiles, docsFileName, this.host);
         return true;
     }
 
     private async restartLuauLSP(
-        defsFile: string,
+        defsFiles: {[k:string]:string},
         docsFile: string,
         _host: HostInterface,
     ): Promise<void> {
@@ -180,9 +189,14 @@ export class LuaLSPPlugin extends BasePlugin {
             // Discard array config, theres not much else we can do to fix it
             luaulspDefs = {}
         }
-        luaulspDefs["sl-slua"] = defsFile;
 
-        await luaulsp.update("types.definitionFiles", luaulspDefs);
+        for(const defKey in luaulspDefs) {
+            if(!defKey.startsWith("sl-")) {
+                defsFiles[defKey] = luaulspDefs[defKey];
+            }
+        }
+        console.error(defsFiles);
+        await luaulsp.update("types.definitionFiles", defsFiles);
         await luaulsp.update("types.documentationFiles", [docsFile]);
         await luaulsp.update("platform.type", "standard");
         await luaulsp.update("sourcemap.enabled", false);
@@ -202,6 +216,35 @@ export class LuaLSPPlugin extends BasePlugin {
             await this.host.writeFile(fullPath, defs);
         } else {
             await vscode.workspace.fs.writeFile(vscode.Uri.file(fullPath), Buffer.from(defs, "utf8"));
+        }
+        return fullPath;
+    }
+
+    private async saveLuauLSPConstantDefs(
+        configPath: NormalizedPath
+    ) : Promise<NormalizedPath> {
+        const basename = `slua_constants.d.luau`;
+        const constants = [
+            ["__LINE__", "number"],
+            ["__FILE__", "string"],
+            ["__SHORTFILE__", "string"],
+            ["__AGENTID__", "string"],
+            ["__AGENTKEY__", "string"],
+            ["__AGENTNAME__", "string"],
+            ["__DATE__", "string"],
+            ["__TIME__", "string"],
+            ["__TIMESTAMP__", "string"],
+            ["__UNIXTIME__", "number"],
+        ];
+        const slua_constants:string[] = constants.reduce<string[]>((acc, cur) => {
+            acc.push(`declare ${cur[0]} : ${cur[1]}`);
+            return acc;
+        },[]);
+        const fullPath = normalizeJoinPath(configPath, basename);
+        if (this.host.writeFile) {
+            await this.host.writeFile(fullPath, slua_constants.join("\n"));
+        } else {
+            await vscode.workspace.fs.writeFile(vscode.Uri.file(fullPath), Buffer.from(slua_constants.join("\n"), "utf8"));
         }
         return fullPath;
     }

--- a/src/scriptsync.ts
+++ b/src/scriptsync.ts
@@ -83,7 +83,7 @@ export class ScriptSync implements vscode.Disposable {
             this.subscribe(scriptId, viewerDocument);
         }
         if(this.language == "luau") {
-            this.config.on(ConfigKey.PreprocessorConstantsInSLua, (config) => {
+            this.config.on(ConfigKey.PreprocessorConstantsInSLua, (_config) => {
                 this.initializeSystemMacros(this.language);
             });
         }

--- a/src/scriptsync.ts
+++ b/src/scriptsync.ts
@@ -82,6 +82,11 @@ export class ScriptSync implements vscode.Disposable {
         if (scriptId && viewerDocument) {
             this.subscribe(scriptId, viewerDocument);
         }
+        if(this.language == "luau") {
+            this.config.on(ConfigKey.PreprocessorConstantsInSLua, (config) => {
+                this.initializeSystemMacros(this.language);
+            });
+        }
     }
 
     //====================================================================
@@ -504,30 +509,36 @@ export class ScriptSync implements vscode.Disposable {
             return;
         }
 
+        if(language === "luau" && !this.config.getConfig<boolean>(ConfigKey.PreprocessorConstantsInSLua, false)) {
+            return;
+        }
+
         this.macros.clear();
         if (language === "lsl") {
-            this.macros.defineSystemMacro("__LINE__", (context) => context.line.toString());
-            this.macros.defineSystemMacro("__FILE__", (context) => `"${path.normalize(context.sourceFile)}"`);
-            this.macros.defineSystemMacro("__SHORTFILE__", (context) => `"${path.basename(path.normalize(context.sourceFile))}"`);
-            this.macros.defineSystemMacro("__AGENTID__", (_context) => `"${ScriptSync.getCurrentAgentId()}"`);
             this.macros.defineSystemMacro("__AGENTKEY__", (_context) => `"${ScriptSync.getCurrentAgentId()}"`);
             this.macros.defineSystemMacro("__AGENTIDRAW__", (_context) => ScriptSync.getCurrentAgentId());
-            this.macros.defineSystemMacro("__AGENTNAME__", (_context) => `"${ScriptSync.getCurrentAgentName()}"`);
-            //this.macros.defineSystemMacro("__ASSETID__", (_context) => `"${getCurrentAssetId()}"`);
-            this.macros.defineSystemMacro("__DATE__", (_context) => {
-                let date = new Date();
-                return `"${date.toISOString().split("T")[0]}"`;
-            });
-            this.macros.defineSystemMacro("__TIME__", (_context) => {
-                let date = new Date();
-                return `"${date.toISOString().split("T")[1].split(".")[0]}"`;
-            });
-            this.macros.defineSystemMacro("__TIMESTAMP__", (_context) => {
-                let date = new Date();
-                return `"${date.toISOString()}"`;
-            });
-            this.macros.defineSystemMacro("__UNIXTIME__", ()=>  `${Math.floor(Date.now() / 1000)}`);
+        } else if(language === "luau") {
+            this.macros.defineSystemMacro("__AGENTKEY__", (_context) => `uuid("${ScriptSync.getCurrentAgentId()}")`);
         }
+        this.macros.defineSystemMacro("__LINE__", (context) => context.line.toString());
+        this.macros.defineSystemMacro("__FILE__", (context) => `"${path.normalize(context.sourceFile)}"`);
+        this.macros.defineSystemMacro("__SHORTFILE__", (context) => `"${path.basename(path.normalize(context.sourceFile))}"`);
+        this.macros.defineSystemMacro("__AGENTID__", (_context) => `"${ScriptSync.getCurrentAgentId()}"`);
+        this.macros.defineSystemMacro("__AGENTNAME__", (_context) => `"${ScriptSync.getCurrentAgentName()}"`);
+        //this.macros.defineSystemMacro("__ASSETID__", (_context) => `"${getCurrentAssetId()}"`);
+        this.macros.defineSystemMacro("__DATE__", (_context) => {
+            let date = new Date();
+            return `"${date.toISOString().split("T")[0]}"`;
+        });
+        this.macros.defineSystemMacro("__TIME__", (_context) => {
+            let date = new Date();
+            return `"${date.toISOString().split("T")[1].split(".")[0]}"`;
+        });
+        this.macros.defineSystemMacro("__TIMESTAMP__", (_context) => {
+            let date = new Date();
+            return `"${date.toISOString()}"`;
+        });
+        this.macros.defineSystemMacro("__UNIXTIME__", ()=>  `${Math.floor(Date.now() / 1000)}`);
     }
 
     public dispose(): void {

--- a/src/shared/lexer.ts
+++ b/src/shared/lexer.ts
@@ -41,6 +41,12 @@ export interface LanguageLexerConfig {
     brackets?: Array<[string, string]>; // Bracket pairs
     stringDelimiters?: string[]; // String delimiters for this language (e.g., ['"', "'"] for LSL, ['"', "'", '`'] for Luau)
     multiLineStringDelimiters?: MultiCharDelimiter[]; // String delimiters for multi line strings (e.g., luau `[[` or `[==[` etc)
+    stringInterpDelimiter?: { // String interpolation delimiter (e.g slua `Hello {name}`)
+        char: string;
+        open: string;
+        close: string;
+        escape: string;
+    }
 }
 
 /**
@@ -111,7 +117,7 @@ export const LANGUAGE_CONFIGS: Record<ScriptLanguage, LanguageLexerConfig> = {
             ["(", ")"],  // Parentheses for expressions and function calls
             ["[", "]"],  // Brackets for table indexing
         ],
-        stringDelimiters: ['"', "'", '`'],  // Double quotes, single quotes, and backticks
+        stringDelimiters: ['"', "'"],  // Double quotes, single quotes
         multiLineStringDelimiters: [
             {
                 startingChar: "[",
@@ -121,6 +127,12 @@ export const LANGUAGE_CONFIGS: Record<ScriptLanguage, LanguageLexerConfig> = {
                 // allowsNewLines: true,
             }
         ],  // Double quotes, single quotes, and backticks
+        stringInterpDelimiter: {
+            char: "`",
+            open: "{",
+            close: "}",
+            escape: "\\",
+        }
     },
 };
 
@@ -155,6 +167,9 @@ export enum TokenType {
 
     // Literals
     STRING_LITERAL = "STRING_LITERAL",
+    STRING_INTERP_START = "STRING_INTERP_START",
+    STRING_INTERP_MIDDLE = "STRING_INTERP_MIDDLE",
+    STRING_INTERP_END = "STRING_INTERP_END",
     NUMBER_LITERAL = "NUMBER_LITERAL",
     VECTOR_LITERAL = "VECTOR_LITERAL",    // <x, y, z> or <x, y, z, w> (LSL vectors/rotations)
 
@@ -324,6 +339,7 @@ interface LexerContext {
     blockCommentEndLength: number; // For Lua long bracket syntax: 2 for --[[, 3 for --[=[, etc calculated using RegexMultiCharDelimiter.lengthDifference.
     lineNumber: number;
     columnNumber: number;
+    interpolatedStringDepth: number[];
 }
 
 //#endregion
@@ -357,6 +373,7 @@ export class Lexer {
             blockCommentEndLength: 0,
             lineNumber: 1,
             columnNumber: 1,
+            interpolatedStringDepth: [],
         };
         this.tokens = [];
         this.sourceFile = sourceFile || ("<unknown>" as NormalizedPath);
@@ -394,6 +411,19 @@ export class Lexer {
                     sourceFile: this.sourceFile,
                 },
                 ErrorCodes.UNTERMINATED_BLOCK_COMMENT
+            );
+        }
+        // Check for unterminated string interp
+        if(this.context.interpolatedStringDepth.length > 0) {
+            this.diagnostics.addError(
+                `Unterminated interpolation string`,
+                {
+                    line: this.context.lineNumber,
+                    column: this.context.columnNumber,
+                    length: 0,
+                    sourceFile: this.sourceFile,
+                },
+                ErrorCodes.UNTERMINATED_STRING
             );
         }
 
@@ -451,6 +481,15 @@ export class Lexer {
             return this.readStringLiteral(char);
         }
 
+        // Interpolated String
+        if(this.isInterpolatedStringStart(char)) {
+            return this.readInterpolatedString(char, true);
+        }
+
+        if(this.isStringInterpResume(char)) {
+            return this.readInterpolatedString(char, false)
+        }
+
         // Multi line strings -- check configured delimiters
         if(this.config.multiLineStringDelimiters) {
             const multiLineStringDelimiter = this.isMultiCharBlockStart(this.config.multiLineStringDelimiters);
@@ -505,6 +544,34 @@ export class Lexer {
             startColumn,
             value.length
         );
+    }
+
+    private isInterpolatedStringStart(char: string) : boolean {
+        if(!this.config.stringInterpDelimiter) return false;
+        if(char == this.config.stringInterpDelimiter.char) {
+            this.context.interpolatedStringDepth.push(1);
+            return true;
+        }
+        return false;
+    }
+
+    private isStringInterpResume(char: string): boolean {
+        if(!this.config.stringInterpDelimiter) return false;
+
+        const interp = this.context.interpolatedStringDepth;
+        const current = interp.length - 1;
+        if(interp.length < 0) return false;
+
+        if(char == this.config.stringInterpDelimiter.close) {
+            interp[current]--;
+        }
+        if(char == this.config.stringInterpDelimiter.open) {
+            interp[current]++;
+        }
+        if(interp[current] == 0) {
+            return true;
+        }
+        return false;
     }
 
     //#region Character classification
@@ -882,6 +949,99 @@ export class Lexer {
             startLine,
             startColumn,
             value.length
+        );
+    }
+
+
+
+    private readInterpolatedString(char:string, start:boolean) : Token
+    {
+        const startLine = this.context.lineNumber;
+        const startColumn = this.context.columnNumber;
+
+        if(!this.config.stringInterpDelimiter) {
+            this.diagnostics.addError(
+                `Interpolate without interpolate config...`,
+                {
+                    line: startLine,
+                    column: startColumn,
+                    length: 1,
+                    sourceFile: this.sourceFile,
+                },
+                ErrorCodes.UNTERMINATED_STRING
+            );
+            return new Token(
+                TokenType.UNKNOWN,
+                this.advance(),
+                startLine,
+                startColumn,
+                1
+            );
+        }
+        let str = this.advance();
+        char = this.config.stringInterpDelimiter.char;
+        const open = this.config.stringInterpDelimiter.open;
+        const close = this.config.stringInterpDelimiter.close;
+        const escape = this.config.stringInterpDelimiter.escape;
+        let escaped = false;
+        let done = false;
+        while(!this.isAtEnd() && !done) {
+            const next = this.peek();
+            if(!escaped) {
+                if(next == escape) {
+                    escaped = true;
+                } else if(next == open) {
+                    done = true;
+                } else if(next == char) {
+                    done = true;
+                } else if(next == "\n") {
+                    this.diagnostics.addError(
+                        "Unterminated string interpolation",
+                        {
+                            line: startLine,
+                            column: startColumn,
+                            length: str.length,
+                            sourceFile: this.sourceFile,
+                        },
+                        ErrorCodes.UNTERMINATED_STRING
+                    )
+                    break;
+                }
+            } else {
+                escaped = false;
+            }
+
+            str += this.advance();
+        }
+
+        const finish = str.endsWith(char);
+
+        const startType = finish ? TokenType.STRING_LITERAL : TokenType.STRING_INTERP_START;
+        const endType = finish ? TokenType.STRING_INTERP_END : TokenType.STRING_INTERP_MIDDLE;
+
+        if(finish) {
+            const pop = this.context.interpolatedStringDepth.pop();
+            if(pop !== 0 && !(pop == 1 && finish && start)) {
+                this.diagnostics.addError(
+                        `String interpolation ended with depth: ${pop}`,
+                        {
+                            line: startLine,
+                            column: startColumn,
+                            length: str.length,
+                            sourceFile: this.sourceFile,
+                        },
+                        ErrorCodes.UNTERMINATED_STRING
+                    );
+            }
+        }
+
+
+        return new Token(
+            start ? startType : endType,
+            str,
+            startLine,
+            startColumn,
+            str.length
         );
     }
 

--- a/src/shared/lexer.ts
+++ b/src/shared/lexer.ts
@@ -981,7 +981,6 @@ export class Lexer {
         let str = this.advance();
         char = this.config.stringInterpDelimiter.char;
         const open = this.config.stringInterpDelimiter.open;
-        const close = this.config.stringInterpDelimiter.close;
         const escape = this.config.stringInterpDelimiter.escape;
         let escaped = false;
         let done = false;
@@ -1023,15 +1022,15 @@ export class Lexer {
             const pop = this.context.interpolatedStringDepth.pop();
             if(pop !== 0 && !(pop == 1 && finish && start)) {
                 this.diagnostics.addError(
-                        `String interpolation ended with depth: ${pop}`,
-                        {
-                            line: startLine,
-                            column: startColumn,
-                            length: str.length,
-                            sourceFile: this.sourceFile,
-                        },
-                        ErrorCodes.UNTERMINATED_STRING
-                    );
+                    `String interpolation ended with depth: ${pop}`,
+                    {
+                        line: startLine,
+                        column: startColumn,
+                        length: str.length,
+                        sourceFile: this.sourceFile,
+                    },
+                    ErrorCodes.UNTERMINATED_STRING
+                );
             }
         }
 

--- a/src/shared/parser.ts
+++ b/src/shared/parser.ts
@@ -419,7 +419,7 @@ export class Parser {
             const current = parser.current();
             if (current.isString()) {
                 const fileToken = parser.current();
-                console.error("INCLUDE",token,fileToken);
+                // console.error("INCLUDE",token,fileToken);
                 filename = parser.extractStringValue(fileToken.value);
             }
             else if(current.type == TokenType.OPERATOR && current.value == "<") {

--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -116,6 +116,10 @@ export class SynchService implements vscode.Disposable {
                 this.onChangeActiveTextEditor(editor),
         );
 
+        ConfigService.getInstance().on(ConfigKey.PreprocessorConstantsInSLua,() => {
+            this.initializeSyntax();
+        });
+
         this.initializeSyntax();
 
         // TODO: Figure out why restart isn't working on the luau-lsp server

--- a/src/test/suite/lexer-diagnostics.test.ts
+++ b/src/test/suite/lexer-diagnostics.test.ts
@@ -286,4 +286,22 @@ suite('Lexer Diagnostics', () => {
         assert.strictEqual(diagnostics.hasErrors(), false);
         assert.strictEqual(diagnostics.getCount(), 0);
     });
+
+    test('Unterminated SLua string interp - newline', () => {
+        const source = 'local str = `some string\nnew line`';
+        const diagnostics = new DiagnosticCollector();
+        const lexer = new Lexer(source, "luau", testFile, diagnostics);
+        lexer.tokenize();
+        assert.strictEqual(diagnostics.hasErrors(), true);
+        assert.strictEqual(diagnostics.getCount(), 2);
+    });
+
+    test('Unterminated SLua string interp - {', () => {
+        const source = 'local str = `some string{new line';
+        const diagnostics = new DiagnosticCollector();
+        const lexer = new Lexer(source, "luau", testFile, diagnostics);
+        lexer.tokenize();
+        assert.strictEqual(diagnostics.hasErrors(), true);
+        assert.strictEqual(diagnostics.getCount(), 1);
+    });
 });

--- a/src/test/suite/lexingpreprocessor.test.ts
+++ b/src/test/suite/lexingpreprocessor.test.ts
@@ -363,6 +363,59 @@ suite("Lexing Preprocessor Test Suite", () => {
             assert.strictEqual(luauStrings.length, luauSourceStrings.length);
         });
 
+        test("Should support slua string interp", ()=> {
+            const parts = [
+                "local",
+                " ",
+                "a",
+                " ",
+                "=",
+                " ",
+                "`string {",
+                "b",
+                "}`"
+            ];
+            const source = parts.join('');
+            const luauLexer = new Lexer(source, "luau");
+            const luauTokens = luauLexer.tokenize();
+            assert.strictEqual(luauTokens.length, 10);
+            for(const i in parts) {
+                assert.strictEqual(luauTokens[i].value, parts[i]);
+            }
+        });
+
+
+
+        test("Should support nested slua string interp", ()=> {
+            const parts = [
+                "local",
+                " ",
+                "a",
+                " ",
+                "=",
+                " ",
+                "`string {",
+                "b",
+                " ",
+                "..",
+                " ",
+                "`nested{",
+                " ",
+                "`string`",
+                " ",
+                "}`",
+                " ",
+                "}`"
+            ];
+            const source = parts.join('');
+            const luauLexer = new Lexer(source, "luau");
+            const luauTokens = luauLexer.tokenize();
+            assert.strictEqual(luauTokens.length, parts.length + 1);
+            for(const i in parts) {
+                assert.strictEqual(luauTokens[i].value, parts[i]);
+            }
+        });
+
         const tokenizeAndGetStrings = (strings:string[],lang:ScriptLanguage) : string[] => {
             const lexer = new Lexer(strings.join(" "),lang);
             const tokens = lexer.tokenize().filter(t => t.type == TokenType.STRING_LITERAL);


### PR DESCRIPTION
# WARNING 
### THIS PR SHOULD NOT BE MERGED UNTIL AFTER #41 and #42
It contains the work from those pr's as well to avoid merge conflicts

# Main

This adds support to the slua preprocessing for the LSL preproc's predefined macros

This functionality is being a config switch and off by default.

When enabled an extra definition file that contains the constants is generated and loaded into luau-lsp

This pr also adds support to the lexer for luau's string interpolation, allowing macro's to be inserted into strings.

And includes test for the same. Along with an update to the preproc documentation to reflect SLua's constants support.

## Example script
### Source
```luau
ll.OwnerSay(__AGENTID__)
```
### Output
```luau
ll.OwnerSay("677bf9a4-bba5-4cf9-a4ad-4802a0f7ef46")
```

## String interpolation example
### Source
```luau
ll.OwnerSay(`The scripters key is {__AGENTID__}!`)
```
### Output
```luau
ll.OwnerSay(`The scripters key is {"677bf9a4-bba5-4cf9-a4ad-4802a0f7ef46"}!`)
```

