### PR TITLE
Fix non relative paths in @line and @module comments

### DIFF
--- a/src/shared/includeprocessor.ts
+++ b/src/shared/includeprocessor.ts
@@ -129,6 +129,7 @@ export class IncludeProcessor {
         let aliased = false;
 
         if(isRequire) {
+            filename = this.normalizeRequirePath(filename);
             if(!filename.startsWith("@")) {
                 // Regular require, relative lookup
                 includePaths = ["."];
@@ -324,6 +325,15 @@ export class IncludeProcessor {
         };
     }
 
+    private normalizeRequirePath(filename: string): string {
+        if(!filename.includes(path.sep)) {
+            filename = filename.split("/").join(path.sep);
+        }
+        const dbl = path.sep + path.sep;
+        while(filename.includes(dbl)) filename = filename.split(dbl).join(path.sep);
+        return filename;
+    }
+
     private async getLuauRequireAliasDir(requirePath:string, sourceFile:NormalizedPath, state:IncludeState) : Promise<string> {
         if(!requirePath.startsWith("@")) {
             throw "Alias must start with @";
@@ -353,9 +363,13 @@ export class IncludeProcessor {
     private async resolveLuaurcFileAliases(sourceFile:string, rcMap: LuauRCRequireMap) : Promise<RequireMap> {
         const map: RequireMap = {};
         let dir = normalizePath(sourceFile);
-        while(true) {
+        let last = dir;
+        let limit = 25;
+        while(limit-- > 0) {
             dir = normalizePath(path.dirname(dir));
-            if(dir.length < 3) break;
+            if(last == dir) {
+                break;
+            }
             const norm = normalizeJoinPath(dir,".luaurc");
             let dirMap = rcMap[norm] ?? null;
             if(!dirMap) {

--- a/src/shared/parser.ts
+++ b/src/shared/parser.ts
@@ -1748,7 +1748,8 @@ export class Parser {
             [TokenType.PAREN_OPEN,"("],
             [TokenType.PAREN_CLOSE,")"],
             [TokenType.NEWLINE,"\n"],
-            [TokenType.LINE_COMMENT, `${languageConfig.lineCommentPrefix}@line 1 "${this.sourceFile}"`],
+            // [TokenType.LINE_COMMENT, `${languageConfig.lineCommentPrefix}@line 1 "${this.sourceFile}"`],
+            [TokenType.LINE_COMMENT, `${languageConfig.lineCommentPrefix}@line 1 "${this.formatPathForLineDirective(this.sourceFile)}"`],
             [TokenType.NEWLINE,"\n"],
         ];
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -442,6 +442,8 @@ export class VSCodeHost implements HostInterface {
             return vscode.Uri.file(fileName).toString();
         }
 
+        const relatives = [];
+
         // Find which workspace folder contains this file
         for (const folder of workspaceFolders) {
             const folderPath = folder.uri.fsPath;
@@ -452,8 +454,19 @@ export class VSCodeHost implements HostInterface {
                 const normalizedRelative = relativePath.split(path.sep).join('/');
                 // Include folder name in URI to identify which workspace root
                 return `workspace:///${folder.name}/${normalizedRelative}`;
+            } else {
+                const relativePath = path.relative(folderPath, fileName);
+                if(relativePath.startsWith('..')) {
+                    relatives.push(`workspace:///${folder.name}/${relativePath}`);
+                }
             }
         }
+        if(relatives.length > 0) {
+            relatives.sort((a,b) => a.length - b.length);
+            return relatives[0];
+        }
+
+        // return `workspace:///` + vscode.workspace.asRelativePath(fileName);
 
         // File is outside all workspace folders - return absolute file:// URL
         return vscode.Uri.file(fileName).toString();


### PR DESCRIPTION
A fix for some of the preprocesor `@line` and `@module` comments including full files paths.

This also includes a fix for a bug that cause windows includes to possibly loop forever.

Requires now should support both windows or unix style paths,