### PR TITLE
Fix casing of learn more links in luau-lsp docs

### DIFF
--- a/src/shared/docsjsongenerator.ts
+++ b/src/shared/docsjsongenerator.ts
@@ -138,7 +138,7 @@ export class DocsJsonGenerator {
 
         // Generate wiki link for ll.* functions
         if (moduleName === 'll') {
-            entry.learn_more_link = `https://create.secondlife.com/script/slua-reference/functions/ll${func.name}/`
+            entry.learn_more_link = `https://create.secondlife.com/script/slua-reference/functions/ll${func.name.toLowerCase()}/`
         }
 
         docs[key] = entry;
@@ -191,7 +191,7 @@ export class DocsJsonGenerator {
         // Handle different naming conventions
         if (name.startsWith('ll.')) {
             // ll.FunctionName -> https://create.secondlife.com/script/slua-reference/functions/llFunctionName/
-            return `https://create.secondlife.com/script/slua-reference/functions/ll${name.slice(3)}/`;
+            return `https://create.secondlife.com/script/slua-reference/functions/ll${name.slice(3).toLowerCase()}/`;
         }
 
         if (name === 'uuid' || name === 'vector' || name === 'quaternion') {


### PR DESCRIPTION
The generated docs json for luau-lsp, currently produces links like this

<img width="928" height="214" alt="image" src="https://github.com/user-attachments/assets/a9383fc0-cd15-4102-acc2-32b30a545d83" />

This produces a 404 as all function pages on the create wiki are lowercase only.

<img width="789" height="316" alt="image" src="https://github.com/user-attachments/assets/b9bcb601-a0ac-43d2-85b4-6e0d8fb2ec1c" />


This pr just adds `.toLowerCase()` to the function name parts of those links