### PR TITLE
Disable-auto-language-update

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,11 @@
             "default": true,
             "description": "Whether the SL VS Code extension is enabled"
           },
+          "slVscodeEdit.autoUpdateLanguageFiles": {
+            "type": "boolean",
+            "default": true,
+            "description": "If false, do not update Luau-LSP and Selene configurations unless the Force Language Update is done"
+          },
           "slVscodeEdit.ui.statusTimeoutSeconds": {
             "type": "number",
             "default": 3,

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
             "default": true,
             "description": "Whether the SL VS Code extension is enabled"
           },
-          "slVscodeEdit.autoUpdateLanguageFiles": {
+          "slVscodeEdit.syntax.autoUpdate": {
             "type": "boolean",
             "default": true,
             "description": "If false, do not update Luau-LSP and Selene configurations unless the Force Language Update is done"

--- a/src/interfaces/configinterface.ts
+++ b/src/interfaces/configinterface.ts
@@ -12,6 +12,7 @@ import { NormalizedPath } from './hostinterface';
 /** Keys used by configuration (mirrors LLConfigNames). */
 export enum ConfigKey {
   Enabled = 'enabled',
+  AutoUpdateLanguageFiles = 'autoUpdateLanguageFiles',
   ClientName = 'client.name',
   ClientVersion = 'client.version',
   ClientProtocolVersion = 'client.protocolVersion',

--- a/src/interfaces/configinterface.ts
+++ b/src/interfaces/configinterface.ts
@@ -12,7 +12,7 @@ import { NormalizedPath } from './hostinterface';
 /** Keys used by configuration (mirrors LLConfigNames). */
 export enum ConfigKey {
   Enabled = 'enabled',
-  AutoUpdateLanguageFiles = 'autoUpdateLanguageFiles',
+  AutoUpdateLanguageFiles = 'syntax.autoUpdate',
   ClientName = 'client.name',
   ClientVersion = 'client.version',
   ClientProtocolVersion = 'client.protocolVersion',

--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -551,6 +551,10 @@ export class SynchService implements vscode.Disposable {
 
     public async forceLanguageUpdate(): Promise<void> {
         const service = LanguageService.getInstance();
+        const defaultSuccess = await service.changeSyntaxVersion('default');
+        if (!defaultSuccess) {
+            showWarningMessage("Failed to update default syntax.");
+        }
         const socket = this.getWebSocket();
         if (!socket || !socket.isConnected()) {
             showWarningMessage("No viewer connection for syntax update.");

--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -139,6 +139,10 @@ export class SynchService implements vscode.Disposable {
     }
 
     private async initializeSyntax(): Promise<void> {
+        const autoUpdate: boolean = ConfigService.getInstance().getConfig<boolean>(ConfigKey.AutoUpdateLanguageFiles) != false
+        if (!autoUpdate) {
+            return;
+        }
         let loaded = false;
         const lastSyntaxID = ConfigService.getInstance().getConfig<string>(ConfigKey.LastSyntaxID);
         const languageService = LanguageService.getInstance();
@@ -528,6 +532,11 @@ export class SynchService implements vscode.Disposable {
     //====================================================================
     //#region Language version checking and management
     public checkLanguageVersion(): boolean | undefined {
+        const autoUpdate: boolean = ConfigService.getInstance().getConfig<boolean>(ConfigKey.AutoUpdateLanguageFiles) != false
+        if (!autoUpdate) {
+            return true;
+        }
+
         if (!this.syntaxId) {
             return;
         }


### PR DESCRIPTION
- Adds a setting to disable the plugin from updating the language definitions for luau-lsp and selene automatically
- Change `Force Language Update` to work even when not connected to a viewer

I'm using the updated language files from the lsl-definitions repository, and the plugin keeps trying to downgrade them. I can usually revert the changes it made and reload the Luau language server, but this doesn't always work. sometimes problems luau-lsp found when using out-of-date defs don't go away on reload, and I have to restart vscode to get rid of them. But then restarting vscode would cause sl-vscode-plugin to mess up the definitions again