### PR TITLE
Notecard link and `@file` meta linking improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 *.vsix
 *.code-workspace
 .vscode/settings.json
+.vscode/lsl-lsp-server.log

--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
             "type": "boolean",
             "default": false,
             "description": "Whether the current sl user info should be included in the meta info"
+          },
+          "slVscodeEdit.sync.notecardComment": {
+            "type": "string",
+            "default" : null,
+            "description": "String to use as a comment for notecards to allow syncing to external files of notecards with a file comment"
           }
         }
       },

--- a/src/configservice.ts
+++ b/src/configservice.ts
@@ -11,6 +11,8 @@ import { normalizePath, NormalizedPath } from "./interfaces/hostinterface";
 export const STATUS_BAR_TIMEOUT_SECONDS = 3;
 export const SCRIPT_FILE_PATTERN =
   /^sl_script_(.+)_([a-fA-F0-9]{32}|[a-fA-F0-9-]{36})\.(luau|lsl)$/;
+export const NOTECARD_FILE_PATTERN =
+  /^sl_notecard_(.+)_([a-fA-F0-9]{32}|[a-fA-F0-9-]{36})\.txt$/;
 
 
 export const configPrefix = "slVscodeEdit";

--- a/src/interfaces/configinterface.ts
+++ b/src/interfaces/configinterface.ts
@@ -33,6 +33,7 @@ export enum ConfigKey {
   LastSyntaxID = 'syntax.lastID',
   AskIfViewerScriptMismatchesMaster = 'sync.askIfViewerScriptMismatchesMaster',
   CompareHashBeforeSync = 'sync.compareHashBeforeSync',
+  NotecardSyncComment = 'sync.notecardComment',
 
   FileMetaInfoInOutput ='sync.includeFileMetaInOutput',
   FileMetaInfoIncludeCreator ='sync.includeCreatorInFileMeta',

--- a/src/scriptsync.ts
+++ b/src/scriptsync.ts
@@ -29,7 +29,7 @@ import { HostInterface, normalizePath } from "./interfaces/hostinterface";
 import { SynchService } from "./synchservice";
 import { IncludeInfo } from "./shared/parser";
 import { sha256 } from "js-sha256";
-import { getLanguageConfig, LanguageLexerConfig } from "./shared/lexer";
+import { getLanguageConfig, isProccessedLanguage, LanguageLexerConfig } from "./shared/lexer";
 
 //====================================================================
 interface TrackedDocument {
@@ -74,8 +74,8 @@ export class ScriptSync implements vscode.Disposable {
         this.host = host ?? new VSCodeHost();
 
         // Initialize preprocessor with macro processor
-        const enabled = config.getConfig<boolean>(ConfigKey.PreprocessorEnable) ?? true;
-        if (enabled) {
+        const enabled = config.getConfig<boolean>(ConfigKey.PreprocessorEnable, true);
+        if (enabled && isProccessedLanguage(this.language)) {
             this.preprocessor = new LexingPreprocessor(this.host, config, this.macros);
         }
 
@@ -441,7 +441,7 @@ export class ScriptSync implements vscode.Disposable {
     }
 
     private getLanguageConfig(): LanguageLexerConfig {
-        const config = getLanguageConfig(this.language);
+        const config = getLanguageConfig(this.language, this.config);
         if(config.name === "lsl" && this.config.getConfig<boolean>(ConfigKey.PreprocessorLSLSwitchStatements, false)) {
             config.directiveKeywords.push("switch");
         }
@@ -504,14 +504,19 @@ export class ScriptSync implements vscode.Disposable {
         const path = vscode.workspace.asRelativePath(this.masterDocument.uri.fsPath);
 
         const comment =  this.getLanguageConfig().lineCommentPrefix;
+
+        if(comment.length < 1) return content;
+
         meta.push(`${comment} ================ sl-vscode-plugin meta ================`);
         meta.push(`${comment} @file ${path}`);
         meta.push(`${comment} @hash ${hash}`);
         meta.push(`${comment} @date ${date[0]} ${date[1].split(".")[0]}`);
         // console.error("PREFIX CREATOR", this.config.getConfig<boolean>(ConfigKey.FileMetaInfoIncludeCreator,false));
         if(this.config.getConfig<boolean>(ConfigKey.FileMetaInfoIncludeCreator, false)) {
-            meta.push(`${comment} @creator ${ScriptSync.getCurrentAgentName()}`);
-            meta.push(`${comment} @creatorID ${ScriptSync.getCurrentAgentId()}`);
+            const agentName = ScriptSync.getCurrentAgentName();
+            if(agentName) meta.push(`${comment} @creator ${agentName}`);
+            const agentID = ScriptSync.getCurrentAgentId();
+            if(agentID) meta.push(`${comment} @creatorID ${agentID}`);
         }
         meta.push(`${comment} =======================================================`);
         meta.push(content)
@@ -526,12 +531,12 @@ export class ScriptSync implements vscode.Disposable {
         return this.fileMappings.filter(mapping => mapping.hash !== hash);
     }
 
-    private static getCurrentAgentId(): string {
-        return SynchService.getInstance().agentId || "unknown-agent-id";
+    private static getCurrentAgentId(): string | null {
+        return SynchService.getInstance().agentId ?? null;
     }
 
-    private static getCurrentAgentName(): string {
-        return SynchService.getInstance().agentName || "unknown-agent-name";
+    private static getCurrentAgentName(): string | null {
+        return SynchService.getInstance().agentName ?? null;
     }
 
     private initializeSystemMacros(language: ScriptLanguage): void {
@@ -545,16 +550,16 @@ export class ScriptSync implements vscode.Disposable {
 
         this.macros.clear();
         if (language === "lsl") {
-            this.macros.defineSystemMacro("__AGENTKEY__", (_context) => `"${ScriptSync.getCurrentAgentId()}"`);
-            this.macros.defineSystemMacro("__AGENTIDRAW__", (_context) => ScriptSync.getCurrentAgentId());
+            this.macros.defineSystemMacro("__AGENTKEY__", (_context) => `"${ScriptSync.getCurrentAgentId() ?? "unkown-agent-id"}"`);
+            this.macros.defineSystemMacro("__AGENTIDRAW__", (_context) => ScriptSync.getCurrentAgentId() ?? "unkown-agent-id");
         } else if(language === "luau") {
-            this.macros.defineSystemMacro("__AGENTKEY__", (_context) => `uuid("${ScriptSync.getCurrentAgentId()}")`);
+            this.macros.defineSystemMacro("__AGENTKEY__", (_context) => `uuid("${ScriptSync.getCurrentAgentId() ?? "unkown-agent-id"}")`);
         }
         this.macros.defineSystemMacro("__LINE__", (context) => context.line.toString());
         this.macros.defineSystemMacro("__FILE__", (context) => `"${path.normalize(context.sourceFile)}"`);
         this.macros.defineSystemMacro("__SHORTFILE__", (context) => `"${path.basename(path.normalize(context.sourceFile))}"`);
-        this.macros.defineSystemMacro("__AGENTID__", (_context) => `"${ScriptSync.getCurrentAgentId()}"`);
-        this.macros.defineSystemMacro("__AGENTNAME__", (_context) => `"${ScriptSync.getCurrentAgentName()}"`);
+        this.macros.defineSystemMacro("__AGENTID__", (_context) => `"${ScriptSync.getCurrentAgentId() ?? "unknown-agent-id"}"`);
+        this.macros.defineSystemMacro("__AGENTNAME__", (_context) => `"${ScriptSync.getCurrentAgentName() ?? "unknown-agent-name"}"`);
         //this.macros.defineSystemMacro("__ASSETID__", (_context) => `"${getCurrentAssetId()}"`);
         this.macros.defineSystemMacro("__DATE__", (_context) => {
             let date = new Date();

--- a/src/shared/languageservice.ts
+++ b/src/shared/languageservice.ts
@@ -18,7 +18,7 @@ import { SelenePlugin, LuaLSPPlugin } from "../pluginsupport";
 import { ConfigService } from "../configservice";
 
 // TODO: migrate to ConfigInterface injection
-export type ScriptLanguage = "lsl" | "luau";
+export type ScriptLanguage = "lsl" | "luau" | "txt";
 
 //-----------------------------------------
 

--- a/src/shared/lexer.ts
+++ b/src/shared/lexer.ts
@@ -9,6 +9,7 @@
 import { ScriptLanguage } from "./languageservice";
 import { NormalizedPath } from "../interfaces/hostinterface";
 import { DiagnosticCollector, ErrorCodes } from "./diagnostics";
+import { ConfigKey, FullConfigInterface } from "../interfaces/configinterface";
 
 //#region Language Configuration
 
@@ -60,98 +61,114 @@ export interface LanguageLexerConfig extends BaseLanguageLexerConfig {
 
 /**
  * Predefined language configurations
- */
-const LANGUAGE_CONFIGS: Record<ScriptLanguage, LanguageLexerConfig> = {
-    lsl: {
-        name: "lsl",
-        lineCommentPrefix: "//",
-        blockCommentDelimiters: [
-            ["/*","*/"]
-        ],
-        logicalOperators: {
-            and: "&&",
-            or: "||",
-            not: "!"
-        },
-        useLongBracketSyntax: false,
-        supportsVectorLiterals: true,
-        directivePrefix: "#",
-        directiveKeywords: ["defined"],
-        operators: [
-            // Multi-character operators
-            "==", "!=", "<=", ">=", "&&", "||", "<<", ">>",
-            "+=", "-=", "*=", "/=", "%=", "++", "--",
-            // Single-character operators
-            "+", "-", "*", "/", "%", "=", "!", "<", ">", "&", "|", "^", "~",
-            // Punctuation (brackets handled separately as distinct token types)
-            "?", ":", ";", ",", ".",
-        ],
-        brackets: [
-            ["{", "}"],  // Braces for code blocks
-            ["(", ")"],  // Parentheses for expressions and function calls
-            ["[", "]"],  // Brackets for lists
-        ],
-        stringDelimiters: ['"', "'"],  // Double and single quotes
-    },
-    luau: {
-        name: "luau",
-        lineCommentPrefix: "--",
-        blockCommentDelimiters: [
-            {
-                startingChar: "-",
-                endingChar: "]",
-                startingMatch: /^--\[[=]*\[$/, // Regex for `--[=[` with 0-n `=` characters
-                endingMatch: /^\][=]*\]$/, // Regex for `]=]` with 0-n `=` characters
-                lengthDifference: -2, // ending sequence is 2 chars shorter
-            }
-        ],
-        logicalOperators: {
-            and: "and",
-            or: "or",
-            not: "not"
-        },
-        useLongBracketSyntax: true,
-        directivePrefix: null,
-        directiveKeywords: ["require"],
-        operators: [
-            // Arithmetic operators
-            "+", "-", "*", "/", "%", "^",
-            // Relational operators
-            "==", "~=", "<=", ">=", "<", ">",
-            // Logical operators
-            "and", "or", "not",
-            // Other & punctuation (brackets handled separately as distinct token types)
-            "..", "#", "?", ":", ";", ",", ".",
-        ],
-        brackets: [
-            ["{", "}"],  // Braces for code blocks (do...end in Lua, but braces for tables)
-            ["(", ")"],  // Parentheses for expressions and function calls
-            ["[", "]"],  // Brackets for table indexing
-        ],
-        stringDelimiters: ['"', "'"],  // Double quotes, single quotes
-        multiLineStringDelimiters: [
-            {
-                startingChar: "[",
-                endingChar: "]",
-                startingMatch: /^\[[=]*\[$/, // Regex for `[=[` with 0-n `=` characters
-                endingMatch: /^\][=]*\]$/, // Regex for `]=]` with 0-n `=` characters
-                // allowsNewLines: true,
-            }
-        ],  // Double quotes, single quotes, and backticks
-        stringInterpDelimiter: {
-            char: "`",
-            open: "{",
-            close: "}",
-            escape: "\\",
-        }
-    },
-};
-
-/**
  * Get language configuration for a script language
  */
-export function getLanguageConfig(language: ScriptLanguage): LanguageLexerConfig {
-    return structuredClone(LANGUAGE_CONFIGS[language]);
+export function isProccessedLanguage(language: ScriptLanguage): boolean {
+    return language == "lsl" || language == "luau";
+}
+export function getLanguageConfig(language: ScriptLanguage, config: FullConfigInterface|null = null): LanguageLexerConfig {
+    switch (language) {
+        case "lsl":
+            return {
+                name: "lsl",
+                lineCommentPrefix: "//",
+                blockCommentDelimiters: [
+                    ["/*", "*/"]
+                ],
+                logicalOperators: {
+                    and: "&&",
+                    or: "||",
+                    not: "!"
+                },
+                useLongBracketSyntax: false,
+                supportsVectorLiterals: true,
+                directivePrefix: "#",
+                directiveKeywords: ["defined"],
+                operators: [
+                    // Multi-character operators
+                    "==", "!=", "<=", ">=", "&&", "||", "<<", ">>",
+                    "+=", "-=", "*=", "/=", "%=", "++", "--",
+                    // Single-character operators
+                    "+", "-", "*", "/", "%", "=", "!", "<", ">", "&", "|", "^", "~",
+                    // Punctuation (brackets handled separately as distinct token types)
+                    "?", ":", ";", ",", ".",
+                ],
+                brackets: [
+                    ["{", "}"],  // Braces for code blocks
+                    ["(", ")"],  // Parentheses for expressions and function calls
+                    ["[", "]"],  // Brackets for lists
+                ],
+                stringDelimiters: ['"', "'"],  // Double and single quotes
+            };
+        case "luau":
+            return {
+                name: "luau",
+                lineCommentPrefix: "--",
+                blockCommentDelimiters: [
+                    {
+                        startingChar: "-",
+                        endingChar: "]",
+                        startingMatch: /^--\[[=]*\[$/, // Regex for `--[=[` with 0-n `=` characters
+                        endingMatch: /^\][=]*\]$/, // Regex for `]=]` with 0-n `=` characters
+                        lengthDifference: -2, // ending sequence is 2 chars shorter
+                    }
+                ],
+                logicalOperators: {
+                    and: "and",
+                    or: "or",
+                    not: "not"
+                },
+                useLongBracketSyntax: true,
+                directivePrefix: null,
+                directiveKeywords: ["require"],
+                operators: [
+                    // Arithmetic operators
+                    "+", "-", "*", "/", "%", "^",
+                    // Relational operators
+                    "==", "~=", "<=", ">=", "<", ">",
+                    // Logical operators
+                    "and", "or", "not",
+                    // Other & punctuation (brackets handled separately as distinct token types)
+                    "..", "#", "?", ":", ";", ",", ".",
+                ],
+                brackets: [
+                    ["{", "}"],  // Braces for code blocks (do...end in Lua, but braces for tables)
+                    ["(", ")"],  // Parentheses for expressions and function calls
+                    ["[", "]"],  // Brackets for table indexing
+                ],
+                stringDelimiters: ['"', "'"],  // Double quotes, single quotes
+                multiLineStringDelimiters: [
+                    {
+                        startingChar: "[",
+                        endingChar: "]",
+                        startingMatch: /^\[[=]*\[$/, // Regex for `[=[` with 0-n `=` characters
+                        endingMatch: /^\][=]*\]$/, // Regex for `]=]` with 0-n `=` characters
+                        // allowsNewLines: true,
+                    }
+                ],  // Double quotes, single quotes, and backticks
+                stringInterpDelimiter: {
+                    char: "`",
+                    open: "{",
+                    close: "}",
+                    escape: "\\",
+                }
+            };
+        case "txt": {
+            const prefix = config ? config.getConfig<string|null>(ConfigKey.NotecardSyncComment, null) : null;
+            return {
+                name: "txt",
+                lineCommentPrefix: prefix ?? "",
+                blockCommentDelimiters: [],
+                logicalOperators: {
+                    and: "",
+                    or: "",
+                    not: ""
+                },
+                directivePrefix: prefix,
+                directiveKeywords: []
+            };
+        }
+    }
 }
 
 //#endregion

--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -746,8 +746,6 @@ export class SynchService implements vscode.Disposable {
     ) : Promise<vscode.Uri | null> {
         const config =  ConfigService.getInstance()
 
-        if (!config.getConfig<boolean>(ConfigKey.FileMetaInfoInOutput, false)) return null;
-
         const cmt = getLanguageConfig(script.language,config).lineCommentPrefix;
 
         if(cmt.length < 1) return null;

--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -136,6 +136,12 @@ export class SynchService implements vscode.Disposable {
         this.disposables.push(onDidSaveListener);
         this.disposables.push(onDidChangeWindowState);
         this.disposables.push(onDidChangeActiveTextEditor);
+
+        const launchDoc = vscode.window.activeTextEditor?.document
+
+        if(launchDoc) {
+            this.onOpenTextDocument(launchDoc);
+        }
     }
 
     private async initializeSyntax(): Promise<void> {

--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -5,7 +5,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
-import { SCRIPT_FILE_PATTERN, ConfigService } from "./configservice";
+import { SCRIPT_FILE_PATTERN, ConfigService, NOTECARD_FILE_PATTERN } from "./configservice";
 import { ConfigKey } from "./interfaces/configinterface";
 import {
     ViewerEditWSClient,
@@ -578,6 +578,12 @@ export class SynchService implements vscode.Disposable {
     private static parseTempFile(
         viewerFilePath: string,
     ): ParsedTempFile | null {
+        return SynchService.parseTempScriptFile(viewerFilePath) ?? SynchService.parseTempNotecardFile(viewerFilePath);
+    }
+
+    private static parseTempScriptFile(
+        viewerFilePath: string,
+    ): ParsedTempFile | null {
         const openedBase = path.basename(viewerFilePath);
         const match = openedBase.match(SCRIPT_FILE_PATTERN);
 
@@ -587,6 +593,22 @@ export class SynchService implements vscode.Disposable {
                 scriptId: match[2],
                 extension: match[3],
                 language: match[3].toLowerCase() == "lsl" ? "lsl" : "luau",
+            }
+            : null;
+    }
+
+    private static parseTempNotecardFile(
+        viewerFilePath: string,
+    ): ParsedTempFile | null {
+        const openedBase = path.basename(viewerFilePath);
+        const match = openedBase.match(NOTECARD_FILE_PATTERN);
+
+        return match
+            ? {
+                scriptName: match[1],
+                scriptId: match[2],
+                extension: "txt",
+                language: "txt",
             }
             : null;
     }
@@ -627,19 +649,8 @@ export class SynchService implements vscode.Disposable {
         viewerFile: vscode.TextDocument
     ): Promise<vscode.Uri | null> {
         // Attempt to match by file meta info
-        if (ConfigService.getInstance().getConfig<boolean>(ConfigKey.FileMetaInfoInOutput, false)) {
-            const cmt = getLanguageConfig(script.language).lineCommentPrefix;
-            const lineRegExp = new RegExp(`^[\\s]*${cmt}[\\s]*@file[\\s]*[A-z0-9-_/.]*[\\s]*$`, "i");
-            const range = new vscode.Range(0, 0, 10, 0);
-            const start = viewerFile.getText(range).split("\n").filter(line => line.match(lineRegExp))[0] ?? null;
-            if (start) {
-                const files = await vscode.workspace.findFiles(start.split("@file")[1].trim());
-                if (files.length == 1) {
-                    console.warn("Match on meta info");
-                    return files[0];
-                }
-            }
-        }
+        const metaMatch = SynchService.findMasterFileByMetaComment(script, viewerFile);
+        if(metaMatch) return metaMatch;
 
         let files = await vscode.workspace.findFiles(`**/${script.scriptName}.${script.extension}`);
         if (files.length > 0) {
@@ -669,6 +680,31 @@ export class SynchService implements vscode.Disposable {
             }
             return null
         }
+    }
+
+    private static async findMasterFileByMetaComment(
+        script: ParsedTempFile,
+        viewerFile: vscode.TextDocument
+    ) : Promise<vscode.Uri | null> {
+        const config =  ConfigService.getInstance()
+
+        if (!config.getConfig<boolean>(ConfigKey.FileMetaInfoInOutput, false)) return null;
+
+        const cmt = getLanguageConfig(script.language,config).lineCommentPrefix;
+
+        if(cmt.length < 1) return null;
+
+        const lineRegExp = new RegExp(`^[\\s]*${cmt}[\\s]*@file[\\s]*[A-z0-9-_/.]*[\\s]*$`, "i");
+        const range = new vscode.Range(0, 0, 10, 0);
+        const start = viewerFile.getText(range).split("\n").filter(line => line.match(lineRegExp))[0] ?? null;
+        if (start) {
+            const files = await vscode.workspace.findFiles(start.split("@file")[1].trim());
+            if (files.length == 1) {
+                console.log("Match on meta info", start);
+                return files[0];
+            }
+        }
+        return null;
     }
 
     private static async openMasterScript(

--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -682,6 +682,58 @@ export class SynchService implements vscode.Disposable {
         }
     }
 
+    // Resolve file by checking actual paths, not searching with globs as, filenames may contain glob special characters
+    private static async resolveUriFromMetaFilePath(
+        pathPart: string,
+    ): Promise<vscode.Uri | null> {
+        const trimmed = pathPart.trim();
+        if (!trimmed) {
+            return null;
+        }
+
+        const isWindowsDrive = /^[a-zA-Z]:[\\/]/.test(trimmed);
+        const isAbs = path.isAbsolute(trimmed) || isWindowsDrive;
+
+        const tryUriInWorkspace = async (uri: vscode.Uri): Promise<vscode.Uri | null> => {
+            if (!vscode.workspace.getWorkspaceFolder(uri)) {
+                return null;
+            }
+            try {
+                const st = await vscode.workspace.fs.stat(uri);
+                if (st.type === vscode.FileType.File) {
+                    return uri;
+                }
+            } catch {
+                // Miss
+            }
+            return null;
+        };
+
+        if (isAbs) {
+            const uri = vscode.Uri.file(path.normalize(trimmed));
+            return tryUriInWorkspace(uri);
+        }
+
+        const folders = vscode.workspace.workspaceFolders;
+        if (!folders?.length) {
+            return null;
+        }
+        // Split path windows or unix style
+        const segments = trimmed
+            .replace(/\\/g, "/")
+            .split("/")
+            .filter((s) => s.length > 0);
+        for (const folder of folders) {
+            const joined = path.join(folder.uri.fsPath, ...segments);
+            const candidate = vscode.Uri.file(path.normalize(joined));
+            const hit = await tryUriInWorkspace(candidate);
+            if (hit) {
+                return hit;
+            }
+        }
+        return null;
+    }
+
     private static async findMasterFileByMetaComment(
         script: ParsedTempFile,
         viewerFile: vscode.TextDocument
@@ -694,14 +746,15 @@ export class SynchService implements vscode.Disposable {
 
         if(cmt.length < 1) return null;
 
-        const lineRegExp = new RegExp(`^[\\s]*${cmt}[\\s]*@file[\\s]*[A-z0-9-_/.]*[\\s]*$`, "i");
+        const lineRegExp = new RegExp(`^[\\s]*${cmt}[\\s]*@file[\\s]+.*$`, "i");
         const range = new vscode.Range(0, 0, 10, 0);
-        const start = viewerFile.getText(range).split("\n").filter(line => line.match(lineRegExp))[0] ?? null;
+        const lines = viewerFile.getText(range).split("\n");
+        const start = lines.filter(line => line.match(lineRegExp))[0] ?? null;
         if (start) {
-            const files = await vscode.workspace.findFiles(start.split("@file")[1].trim());
-            if (files.length == 1) {
-                console.log("Match on meta info", start);
-                return files[0];
+            const pathPart = start.split("@file")[1]?.trim() ?? "";
+            const resolved = await SynchService.resolveUriFromMetaFilePath(pathPart);
+            if (resolved) {
+                return resolved;
             }
         }
         return null;


### PR DESCRIPTION
This adds basic support for linking notecards to local files via the `@file` meta or having `.txt` files.

I have not added this to the documentation, as full implementation may require some viewer updates.

There is a config flag to set a comment string for notecards, for use if a scripter uses notecards as some sort of configuration scheme.

This also include a change to how `@file` is handled as there were instances of it failing due to special characters.