### PR TITLE
Allow notecards without extension in name to still link

### DIFF
--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -53,7 +53,7 @@ import { HostInterface } from "./interfaces/hostinterface";
 import { SyncedFileDecorator } from "./vscode/SyncedFileDecorator";
 import { ObjectContentService } from "./vscode/objectcontentservice";
 import { ObjectPinStore } from "./vscode/objectpinstore";
-import { SL_SCHEME, SL_AUTHORITY, displayName, itemUri } from "./vscode/objectcontentprovider";
+import { SL_SCHEME, SL_AUTHORITY, displayName, itemUri, languageForItem } from "./vscode/objectcontentprovider";
 
 /** PERM_MODIFY bit from viewer LLPermissions */
 const PERM_MODIFY = 0x4000;
@@ -867,11 +867,16 @@ export class SynchService implements vscode.Disposable {
 
         const fullName = displayName(item);           // e.g. "My Script.luau"
         const di = fullName.lastIndexOf('.');
-        if (di < 0) return null;
+        if (di < 0) {
+            if(item.type == "notecard") {
+                return {scriptName: item.name, scriptId: uri.toString(), extension: "txt", language: "txt", item};
+            }
+            return null;
+        }
 
         const scriptName = fullName.slice(0, di);     // "My Script"
         const extension = fullName.slice(di + 1).toLowerCase(); // "luau"
-        const language: ScriptLanguage = extension === 'lsl' ? 'lsl' : 'luau';
+        const language = languageForItem(item);
 
         return { scriptName, scriptId: uri.toString(), extension, language, item };
     }

--- a/src/vscode/objectcontentprovider.ts
+++ b/src/vscode/objectcontentprovider.ts
@@ -15,6 +15,7 @@ import {
     ObjectItemCreateParams,
     ScriptVM,
 } from "./objectcontentinterfaces";
+import { ScriptLanguage } from "../shared/languageservice";
 
 // ============================================
 // Constants
@@ -276,12 +277,17 @@ export function itemUri(root_id: string, prim_id: string, item_id: string): vsco
 /** Map item subtype to the appropriate file extension for display */
 function extensionForItem(item: ObjectInventoryItem): string {
     if (item.type === "notecard") return ""; // no synthetic extension; user-supplied extension stays in the name
-    return item.subtype === 1 ? ".luau" : ".lsl";
+    return `.${languageForItem(item)}`;
 }
 
 /** Returns the display filename (name + synthetic extension) */
 export function displayName(item: ObjectInventoryItem): string {
     return item.name + extensionForItem(item);
+}
+
+export function languageForItem(item: ObjectInventoryItem) : ScriptLanguage {
+    if(item.type == "notecard") return "txt";
+    return item.subtype === 1 ? "luau" : "lsl";
 }
 
 /**


### PR DESCRIPTION
Assume a `.txt` extension for notecards if they don't have an extension in their name.

This also allows notecards without an extension in their name to link via meta comment