### PR TITLE
Fix #106 active syncs not switching to new names if script is renamed

### DIFF
--- a/src/scriptsync.ts
+++ b/src/scriptsync.ts
@@ -31,6 +31,7 @@ import { SynchService } from "./synchservice";
 import { IncludeInfo } from "./shared/parser";
 import { sha256 } from "js-sha256";
 import { getLanguageConfig, isProccessedLanguage, LanguageLexerConfig } from "./shared/lexer";
+import { ObjectInventoryItem } from "./vscode/objectcontentinterfaces";
 
 //====================================================================
 interface TrackedLocalFile {
@@ -46,6 +47,7 @@ interface TrackedVirtualFile {
     id: string;   // uri.toString() — stable unique key
     uri: vscode.Uri;
     hash?: string;
+    item?: ObjectInventoryItem;
 }
 
 type TrackedFile = TrackedLocalFile | TrackedVirtualFile;
@@ -140,7 +142,7 @@ export class ScriptSync implements vscode.Disposable {
 
         this.fileMappings.push(mapping);
 
-        console.log("Subscribeing.");
+        console.log(this.masterDocument.uri.toString(),"subscribing to", id);
         // on initial subscription, we need to generate an initial line mapping
         if (this.fileMappings.filter(m => m.kind === 'local').length === 1) {
             this.lineMappings = LineMapper.parseLineMappingsFromContent(
@@ -152,12 +154,13 @@ export class ScriptSync implements vscode.Disposable {
         return true;
     }
 
-    public subscribeVirtual(uri: vscode.Uri, viewerContent?: string): boolean {
+    public subscribeVirtual(uri: vscode.Uri, viewerContent?: string, item?: ObjectInventoryItem): boolean {
         const id = uri.toString();
         if (this.isTrackingId(id)) {
             return false; // already tracking
         }
-        this.fileMappings.push({ kind: 'virtual', id, uri });
+        console.log(this.masterDocument.uri.toString(),"subscribing to", id);
+        this.fileMappings.push({ kind: 'virtual', id, uri, item });
         if (viewerContent) {
             this.lineMappings = LineMapper.parseLineMappingsFromContent(viewerContent, this.language, new VSCodeHost());
         }
@@ -165,9 +168,8 @@ export class ScriptSync implements vscode.Disposable {
     }
 
     public unsubscribeById(id: string, close?: boolean): number {
-        const mapping = this.fileMappings.find((m) => m.id === id);
+        const mapping = this.unsubscribeInternal(id);
         if (mapping) {
-            this.fileMappings = this.fileMappings.filter((m) => m !== mapping);
             if (close) {
                 if (mapping.kind === 'local') {
                     closeTextDocument(mapping.viewerDocument);
@@ -179,6 +181,15 @@ export class ScriptSync implements vscode.Disposable {
             }
         }
         return this.fileMappings.length;
+    }
+
+    private unsubscribeInternal(id: string) : TrackedFile | undefined
+    {
+        const mapping = this.fileMappings.find((m) => m.id === id);
+        if (!mapping) return;
+        console.error(this.masterDocument.uri.toString(),"unsubscribing from",id);
+        this.fileMappings = this.fileMappings.filter((m) => m !== mapping);
+        return mapping;
     }
 
     public unsubscribeByFile(viewerFile: string, close?: boolean): number {
@@ -196,6 +207,17 @@ export class ScriptSync implements vscode.Disposable {
 
     public unsubscribeVirtualByUri(uri: vscode.Uri, close?: boolean): void {
         this.unsubscribeById(uri.toString(), close);
+    }
+
+    public updateVirtualItem(uri: vscode.Uri, item: ObjectInventoryItem): void {
+        const original = this.fileMappings.find(
+            (m): m is TrackedVirtualFile =>
+                m.kind === 'virtual' && m.item?.item_id === item.item_id,
+        );
+        if(!original) return;
+        const mapping = this.unsubscribeInternal(original.id);
+        if(!mapping) return;
+        this.subscribeVirtual(uri,undefined,item);
     }
 
     public evictVirtualMappingsForObject(object_id: string): void {
@@ -224,6 +246,27 @@ export class ScriptSync implements vscode.Disposable {
 
     public isTrackingVirtualUri(uri: vscode.Uri): boolean {
         return this.isTrackingId(uri.toString());
+    }
+
+    public isTrackingVirtualItem(item: ObjectInventoryItem): boolean {
+        return this.fileMappings.some(
+            (m): m is TrackedVirtualFile =>
+                m.kind === 'virtual' && m.item?.item_id === item.item_id,
+        );
+    }
+
+    public isTrackingVirtualItemInObject(object_id: string) : boolean {
+        return this.fileMappings.some(
+            (m): m is TrackedVirtualFile =>
+                m.kind === "virtual" && m.id.includes(object_id)
+        );
+    }
+
+    public getTrackedVirtualItemsInObject(object_id: string) : TrackedVirtualFile[] {
+        return this.fileMappings.filter(
+            (m): m is TrackedVirtualFile =>
+                m.kind === "virtual" && m.id.includes(object_id)
+        )
     }
 
     public hasFilesToTrack() : boolean {

--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -51,7 +51,7 @@ import { ScriptSync } from "./scriptsync";
 import { getLanguageConfig } from "./shared/lexer";
 import { HostInterface } from "./interfaces/hostinterface";
 import { SyncedFileDecorator } from "./vscode/SyncedFileDecorator";
-import { ObjectContentService } from "./vscode/objectcontentservice";
+import { ObjectContentChangeEvent, ObjectContentService, ObjectTreeChangeEvent } from "./vscode/objectcontentservice";
 import { ObjectPinStore } from "./vscode/objectpinstore";
 import { SL_SCHEME, SL_AUTHORITY, displayName, itemUri } from "./vscode/objectcontentprovider";
 
@@ -173,6 +173,18 @@ export class SynchService implements vscode.Disposable {
             this.initializeSyntax();
         });
 
+        const onViewerDidChangeContent = ObjectContentService.getInstance().onDidChangeContent(
+            (e: ObjectContentChangeEvent) => {
+                this.onViewerDidChangeContent(e);
+            }
+        );
+
+        const onViewerDidChangeObjects = ObjectContentService.getInstance().onDidChangeObjects(
+            (e: ObjectTreeChangeEvent) => {
+                this.onViewerDidChangeObjects(e);
+            }
+        )
+
         // TODO: Figure out why restart isn't working on the luau-lsp server
         // TODO: Bug when prepping language syntax on download
         // const syntaxInit = this.initializeSyntax();
@@ -186,6 +198,8 @@ export class SynchService implements vscode.Disposable {
         this.disposables.push(onDidChangeWindowState);
         this.disposables.push(onDidChangeActiveTextEditor);
         this.disposables.push(vscode.window.registerFileDecorationProvider(this.syncedFileDecorator));
+        this.disposables.push(onViewerDidChangeContent);
+        this.disposables.push(onViewerDidChangeObjects);
 
         const launchDoc = vscode.window.activeTextEditor?.document
 
@@ -372,7 +386,7 @@ export class SynchService implements vscode.Disposable {
         const sync = await this.getOrCreateSync(masterEditor.document, parsed.language);
         // openTextDocument guarantees readFile has completed for virtual fs documents
         const loadedDoc = await vscode.workspace.openTextDocument(slDocument.uri);
-        sync.subscribeVirtual(slDocument.uri, loadedDoc.getText());
+        sync.subscribeVirtual(slDocument.uri, loadedDoc.getText(), parsed.item);
         SynchService.checkAndUpdateMasterDocumentInBackground(masterEditor, slDocument);
         this.syncedFileDecorator.refresh(masterEditor.document.uri);
         logInfo(
@@ -1210,6 +1224,34 @@ export class SynchService implements vscode.Disposable {
             // this event, if so we can assume the viewer launched us
             this.lastActiveChange = Date.now();
             this.activeSync = syncs.pop();
+        }
+    }
+
+    private onViewerDidChangeContent(e: ObjectContentChangeEvent): void {
+        const objectcontentservice = ObjectContentService.getInstance();
+        const item = objectcontentservice.getItem(e.object_id,e.prim_id,e.item_id);
+        if(!item)return;
+        const uri = itemUri(e.object_id, e.prim_id, displayName(item));
+        for(const sync of this.activeSyncs.values()) {
+            if(sync.isTrackingVirtualItem(item)) {
+                sync.updateVirtualItem(uri,item);
+            }
+        }
+    }
+
+    private onViewerDidChangeObjects(e: ObjectTreeChangeEvent): void {
+        const objectContentService = ObjectContentService.getInstance();
+        for(const sync of this.activeSyncs.values()) {
+            if(!sync.isTrackingVirtualItemInObject(e.object_id)) continue;
+            const mappings = sync.getTrackedVirtualItemsInObject(e.object_id);
+            for(const mapping of mappings) {
+                if(!mapping.item) continue;
+                const newItem = objectContentService.getItemInObject(e.object_id, undefined, mapping.item.item_id)
+                if(newItem) {
+                    const uri = itemUri(newItem.object_id, newItem.prim_id, displayName(newItem.item));
+                    sync.updateVirtualItem(uri, newItem.item);
+                }
+            }
         }
     }
     //#endregion

--- a/src/vscode/objectcontentservice.ts
+++ b/src/vscode/objectcontentservice.ts
@@ -15,6 +15,7 @@ import {
     InventoryChanges,
     ScriptVM,
 } from "./objectcontentinterfaces";
+import { displayName, itemUri } from "./objectcontentprovider";
 
 // ============================================
 // Event Types
@@ -314,6 +315,32 @@ export class ObjectContentService implements vscode.Disposable {
         this._onDidChangeScriptVm.fire({ object_id, prim_id, item_id, vm: vmTyped });
     }
 
+    getItemInObject(object_id: string, prim_id: string|undefined, item_id: string) : {object_id:string,prim_id:string,item:ObjectInventoryItem}|undefined {
+        const entry = this.objects.get(object_id);
+        if(!entry) return undefined;
+        if(prim_id == object_id) {
+            const item = entry.object.inventory.find(i => i.item_id == item_id);
+            if(!item) return undefined;
+            return {object_id,prim_id:object_id,item};
+        }
+        if(prim_id) {
+            const link = (entry.object.linked_objects ?? []).find(l => l.link_id == prim_id);
+            if(!link) return undefined;
+            const item = link.inventory.find(i => i.item_id == item_id);
+            if(!item) return undefined;
+            return {object_id,prim_id,item};
+        }
+        const objectItem = entry.object.inventory.find(i => i.item_id == item_id);
+        if(objectItem) {
+            return {object_id,prim_id:object_id,item:objectItem};
+        }
+        for(const link of entry.object.linked_objects ?? []) {
+            const linkItem = link.inventory.find(i => i.item_id == item_id);
+            if(linkItem) return {object_id, prim_id:link.link_id, item:linkItem};
+        }
+        return undefined;
+    }
+
     // ============================================
     // Content Cache
     // ============================================
@@ -349,6 +376,31 @@ export class ObjectContentService implements vscode.Disposable {
 
     isContentDirty(object_id: string, item_id: string): boolean {
         return this.objects.get(object_id)?.contentCache.get(item_id)?.dirty ?? false;
+    }
+
+    getParentsOfInventoryItem(item_id: string) : string[]|undefined {
+        for (const [object_id, entry] of this.objects) {
+            for (const inventory of entry.object.inventory ?? []) {
+                if (inventory.item_id === item_id) {
+                    return [object_id];
+                }
+            }
+            for (const linkedObject of entry.object.linked_objects ?? []) {
+                if (linkedObject.inventory?.some(i => i.item_id === item_id)) {
+                    return [object_id, linkedObject.link_id];
+                }
+            }
+        }
+        return undefined;
+    }
+
+
+    getUriForInventoryItem(item: ObjectInventoryItem) : vscode.Uri|undefined {
+        const parents = this.getParentsOfInventoryItem(item.item_id);
+        if (!parents || parents.length < 1) return undefined;
+        const root = parents[0];
+        const prim = parents.length > 1 ? parents[1] : root;
+        return itemUri(root, prim, displayName(item));
     }
 
     // ============================================


### PR DESCRIPTION
Fixes #106

Added listeners to `SynchService` that listen to the events raised by `ObjectContentService` for items being renamed or inventories resent.

Then if an active sync cares about an item in one of those updates, the sync is now updated to target the new item name