### PR TITLE
Issue #109: Initialize the language server with SL defs at startup.

### DIFF
--- a/src/synchservice.ts
+++ b/src/synchservice.ts
@@ -200,10 +200,9 @@ export class SynchService implements vscode.Disposable {
             }
         )
 
-        // TODO: Figure out why restart isn't working on the luau-lsp server
-        // TODO: Bug when prepping language syntax on download
-        // const syntaxInit = this.initializeSyntax();
-        // showStatusMessage("Initializing syntax...", syntaxInit);
+        this.initialGenerationDone = true;
+        const syntaxInit = this.initializeSyntax();
+        showStatusMessage("Initializing syntax...", syntaxInit);
 
         this.disposables.push(onDidOpenListener);
         // this.disposables.push(onDidCloseListener);
@@ -966,11 +965,16 @@ export class SynchService implements vscode.Disposable {
         let prim_id: string | null = null;
         let item_id: string | undefined;
 
-        if (
-            pathSegments.length >= 2 &&
-            isUuidSegment(pathSegments[0]) &&
-            isUuidSegment(pathSegments[1])
-        ) {
+        if (
+
+            pathSegments.length >= 2 &&
+
+            isUuidSegment(pathSegments[0]) &&
+
+            isUuidSegment(pathSegments[1])
+
+        ) {
+
             prim_id = pathSegments[0];
             item_id = pathSegments[1];
         }

--- a/src/vscode/objectpinstore.ts
+++ b/src/vscode/objectpinstore.ts
@@ -10,6 +10,7 @@ import { rootUri, SL_AUTHORITY, SL_SCHEME } from "./objectcontentprovider";
 const PIN_FILE_VERSION = 1;
 const PIN_FILE_NAME = "sl-object-pins.json";
 const PIN_DIR_NAME = ".vscode";
+const PIN_SUBDIR_NAME = "sl-vscode-plugin";
 
 export interface PinnedObjectRecord {
     uri: string;
@@ -141,7 +142,7 @@ export class ObjectPinStore {
             logDebug("[ObjectPinStore] No file-based workspace folder found while saving pins.");
             return;
         }
-        const pinDirUri = vscode.Uri.joinPath(workspaceRoot, PIN_DIR_NAME);
+        const pinDirUri = vscode.Uri.joinPath(workspaceRoot, PIN_DIR_NAME, PIN_SUBDIR_NAME);
         await vscode.workspace.fs.createDirectory(pinDirUri);
         await vscode.workspace.fs.writeFile(pinFileUri, Buffer.from(serialized, "utf8"));
     }
@@ -264,7 +265,7 @@ export class ObjectPinStore {
         if (root === null) {
             return null;
         }
-        return vscode.Uri.joinPath(root, PIN_DIR_NAME, PIN_FILE_NAME);
+        return vscode.Uri.joinPath(root, PIN_DIR_NAME, PIN_SUBDIR_NAME, PIN_FILE_NAME);
     }
 
     private getWorkspaceRootUri(): vscode.Uri | null {


### PR DESCRIPTION
Fixes #109 

See the original issue for testing instructions.
Before testing delete .vscode/sl-vscode-plugin